### PR TITLE
Vrx urdf generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ docs/_build
 
 # Python compiled files
 *.pyc
+
+# Auto Generated xacros
+NaviGator/simulation/navigator_gazebo/urdf/navigator_vrx/*.xacro

--- a/NaviGator/mission_control/navigator_launch/launch/vrx.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/vrx.launch
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!--
+    Launches the gazebo simulator and all the same master.launch used on the real platform.
+-->
+<launch>
+    <param name="/is_simulation" type="bool" value="True" />
+    <arg name="gui" default="false"/>
+    <arg name="online-bagger" default="False" />
+
+    <!-- Run core navigator code, minus hardware -->
+    <include file="$(find navigator_launch)/launch/master.launch">
+      <arg name="simulation" value="true" />
+      <arg name="online-bagger" value="$(arg online-bagger)" />
+    </include>
+
+    <include file="$(find vrx_gazebo)/launch/vrx.launch">
+      <arg name="gui" value="false"/>
+      <arg name="urdf" value="$(find navigator_gazebo)/urdf/navigator_vrx.urdf"/>
+    </include>
+
+</launch>

--- a/NaviGator/mission_control/navigator_launch/package.xml
+++ b/NaviGator/mission_control/navigator_launch/package.xml
@@ -57,6 +57,7 @@
   <run_depend>point_cloud_object_detection_and_recognition</run_depend>
   <run_depend>navigator_robotx_comms</run_depend>
   <run_depend>mil_poi</run_depend>
+  <run_depend>vrx_gazebo</run_depend>
   <export>
   </export>
 </package>

--- a/NaviGator/simulation/navigator_gazebo/CMakeLists.txt
+++ b/NaviGator/simulation/navigator_gazebo/CMakeLists.txt
@@ -73,6 +73,20 @@ xacro_add_files(
   TARGET xacro_urdf
 )
 
+# Generate Navigator urdf for vrx via yaml files
+add_custom_target(navigator_vrx_urdf ALL
+  DEPENDS ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/urdf/navigator_vrx.urdf
+)
+add_custom_command(
+  OUTPUT ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/urdf/navigator_vrx.urdf
+  COMMAND . ${CATKIN_DEVEL_PREFIX}/setup.sh && roslaunch vrx_gazebo generate_wamv.launch thruster_yaml:=${CMAKE_CURRENT_SOURCE_DIR}/urdf/navigator_vrx/thruster_config.yaml sensor_config:=${CMAKE_CURRENT_SOURCE_DIR}/urdf/navigator_vrx/sensor_config.yaml wamv_target:=${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/urdf/navigator_vrx.urdf
+  DEPENDS urdf/navigator_vrx/thruster_config.yaml urdf/navigator_vrx/sensor_config.yaml
+  DEPENDS ${CATKIN_DEVEL_PREFIX}/setup.sh
+  BYPRODUCTS urdf/navigator_vrx/thruster_config.xacro urdf/navigator_vrx/thruster_config.xacro
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "xacro: generating ${output} from yamls"
+)
+
 # Generate world files from xacro and install
 xacro_add_files(
   worlds/course.world.xacro

--- a/NaviGator/simulation/navigator_gazebo/urdf/navigator_vrx/sensor_config.yaml
+++ b/NaviGator/simulation/navigator_gazebo/urdf/navigator_vrx/sensor_config.yaml
@@ -1,0 +1,25 @@
+wamv_camera:
+    - name: front_left_camera
+      x: 0.75
+      y: 0.1
+      P: ${radians(15)}
+    - name: front_right_camera
+      x: 0.75
+      y: -0.1
+      P: ${radians(15)}
+    - name: middle_right_camera
+      x: 0.75
+      y: 0.3
+      P: ${radians(15)}
+wamv_gps:
+    - name: gps_wamv
+      x: -0.85
+wamv_imu:
+    - name: imu_wamv
+      y: -0.2
+wamv_p3d:
+    - name: p3d_wamv
+lidar:
+    - name: lidar_wamv
+      type: 16_beam
+      P: ${radians(8)}

--- a/NaviGator/simulation/navigator_gazebo/urdf/navigator_vrx/thruster_config.yaml
+++ b/NaviGator/simulation/navigator_gazebo/urdf/navigator_vrx/thruster_config.yaml
@@ -1,0 +1,7 @@
+engine:
+  - prefix: "left"
+    position: "-2.373776 1.027135 0.318237"
+    orientation: "0.0 0.0 0.0"
+  - prefix: "right"
+    position: "-2.373776 -1.027135 0.318237"
+    orientation: "0.0 0.0 0.0"

--- a/scripts/build_docker_containers
+++ b/scripts/build_docker_containers
@@ -21,8 +21,19 @@ build_mil_docker_image()
   docker build $DOCKER_ARGS $DOCKER_BASE_PATH/$1 -t $MIL_DOCKER_TAG_ROOT:$1 --build-arg MIL_DOCKER_TAG_ROOT=${MIL_DOCKER_TAG_ROOT}
 }
 
+build_vrx_images()
+{
+ #build nvidia image
+#  .$(realpath $(dirname $BASH_SOURCE)/../)Navigator/simulation/vrx/docker/build.bash -n $(realpath $(dirname $BASH_SOURCE)/../)Navigator/simulation/vrx/
+ 
+ #build regular image
+  $(realpath $(dirname $BASH_SOURCE)/../)/NaviGator/simulation/vrx/docker/build.bash $(realpath $(dirname $BASH_SOURCE)/../)/NaviGator/simulation/vrx/
+}
+
 # Build each of the images
+build_vrx_images
 build_mil_docker_image base
 build_mil_docker_image dev
 build_mil_docker_image ci-build
 build_mil_docker_image ci-server
+

--- a/scripts/run_development_container
+++ b/scripts/run_development_container
@@ -1,4 +1,5 @@
 #!/bin/bash
 sudo docker run -it \
-    --mount src=$(realpath $(dirname $BASH_SOURCE)/../),target=/home/mil-dev/catkin_ws/src/mil/,type=bind \
+    -v $(realpath $(dirname $BASH_SOURCE)/../):/home/mil-dev/catkin_ws/src/mil/ \
     uf-mil:dev
+

--- a/scripts/run_vrx_container
+++ b/scripts/run_vrx_container
@@ -1,0 +1,2 @@
+#!/bin/bash
+$(realpath $(dirname $BASH_SOURCE)/../)/NaviGator/simulation/vrx/docker/run.bash vrx $(realpath $(dirname $BASH_SOURCE)/../)NaviGator/simulation/vrx/


### PR DESCRIPTION
current status, please advise:
Added vrx.launch(currently does not launch navigator_vrx.urdf). Added navigator_vrx.urdf generation at compile time (currently runs every time, not sure why will not run without ALL). Added a generate_navigator_vrx bash script(this must be done so that the command is run wit hwrtie permissions). Added sensor_config.yaml and thruster_config.yaml for vrx wamv gerneation. Accidentally edited and fixed conf.py(should be identical to master). Changed dev/Dockerfile to have UID=1000 (it was 10000). VRX containers are now built when build_containers is run(currently intel only, no nvidia containers(this will be nessesary to use GPU acceleration in VRX containers later)). Development container now uses an anonymous volume, not a bind mount. Added a script to run the VRX containers(again, no nvidia support).