### PR TITLE
DEV: Dev Container now saves build and devel on host machine

### DIFF
--- a/scripts/build_docker_containers
+++ b/scripts/build_docker_containers
@@ -62,3 +62,10 @@ build_mil_docker_image dev
 build_mil_docker_image ci-build
 build_mil_docker_image ci-server
 
+# Create Space to save build and devel space for dev container
+mkdir -p $HOME/.mil/dev-docker-ws
+chown $UID:1000 -R $HOME/.mil/dev-docker-ws
+
+mkdir -p $HOME/.mil/dev-docker-ws/build
+mkdir -p $HOME/.mil/dev-docker-ws/devel
+

--- a/scripts/run_development_container
+++ b/scripts/run_development_container
@@ -1,6 +1,8 @@
 #!/bin/bash
 sudo docker run -it \
     -v $(realpath $(dirname $BASH_SOURCE)/../):/home/mil-dev/catkin_ws/src/mil/ \
+    -v $HOME/.mil/dev-docker-ws/build:/home/mil-dev/catkin_ws/build/ \
+    -v $HOME/.mil/dev-docker-ws/devel:/home/mil-dev/catkin_ws/devel/ \
     --env="DISPLAY" \
     --env="QT_X11_NO_MITSHM=1" \
     --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \


### PR DESCRIPTION
The Dev container build and devel directories are now saved under the ~/.mil/dev-docker-ws directory. This way we do not have to recompile every time we login to the dev container.

DEMO:
`./scripts/build_docker_containers`
`./scripts/run_development_container`
`cm`
`exit`
`./scripts/run_development_container`
`tmux`
`roslaunch sub8_launch gazebo.launch gui:=true`
*new panel*
`amonitor kill`
`Shift+c`
*new panel*
`submove f 1`

witness the sub move
