### PR TITLE
CI: correctly ignore directories in lint_cpp

### DIFF
--- a/ci/lint_cpp
+++ b/ci/lint_cpp
@@ -8,14 +8,14 @@ MIL_DIR="$(realpath $(dirname $BASH_SOURCE)/..)"
 declare -a FILES=()
 
 # Add any imported submodule / unmanaged code to the excluded list
-for FILE in $(find $MIL_DIR \
-                   -path $MIL_DIR/NaviGator/satellite/rviz_satellite -prune -o \
-                   -path $MIL_DIR/NaviGator/simulation/VRX/vrx -prune -o \
-                   -path $MIL_DIR/mil_common/drivers/pointgrey_camera_driver -prune -o \
-                   -path $MIL_DIR/mil_common/drivers/LMS1xx -prune -o \
-                   -path $MIL_DIR/mil_common/drivers/roboteq -prune -o \
-                   -path $MIL_DIR/mil_common/drivers/mil_blueview_driver/bvtsdk -prune -o \
-                   -path $MIL_DIR/deprecated -prune -o \
+for FILE in $(find $MIL_DIR -type f \
+                   -not -path "$MIL_DIR/NaviGator/satellite/rviz_satellite/*" \
+                   -not -path "$MIL_DIR/NaviGator/simulation/VRX/vrx/*" \
+                   -not -path "$MIL_DIR/mil_common/drivers/pointgrey_camera_driver/*" \
+                   -not -path "$MIL_DIR/mil_common/drivers/LMS1xx/*" \
+                   -not -path "$MIL_DIR/mil_common/drivers/roboteq/*" \
+                   -not -path "$MIL_DIR/mil_common/drivers/mil_blueview_driver/bvtsdk/*" \
+                   -not -path "$MIL_DIR/deprecated/*" \
                    -regex ".*/.*\\.\\(c\\|cc\\|cpp\\|h\\|hpp\\|cxx\\|hxx\\)$"); do
 if [ ! -z "$(clang-format-3.9 -style=file -output-replacements-xml $FILE | grep '<replacement ')" ]; then
   FILES+=( "$FILE" )


### PR DESCRIPTION
Fixes the annoying
```
Is a directory
````
messages in CI lint stage