### PR TITLE
CI: build dev image off env variable base

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,5 @@
-FROM uf-mil:base
+ARG MIL_DOCKER_TAG_ROOT=uf-mil
+FROM ${MIL_DOCKER_TAG_ROOT}:base
 
 # Create a mil-dev user and make them a sudoer
 RUN useradd --uid 1000 --create-home --shell /bin/bash mil-dev \


### PR DESCRIPTION
Correctly builds the dev image from the correct base image in the CI process by using the MIL_DOCKER_BASE_IMAGE env variable