### PR TITLE
Modified indyav_car.urdf.xacro file to use sylphase sensors, and adde…

### DIFF
--- a/IndyAV/simulation/indyav_gazebo/urdf/fixed_link.xacro
+++ b/IndyAV/simulation/indyav_gazebo/urdf/fixed_link.xacro
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro  name="fixed_link"
+                params="name parent='base_link'
+                        xyz:='0 0 0' rpy:='0 0 0'">
+    <link name="${name}" />
+    <joint name="${name}_to_${parent}" type="fixed">
+      <parent link="${parent}" />
+      <child link="${name}" />
+      <origin xyz="${xyz}" rpy="${rpy}" />
+    </joint>
+  </xacro:macro>
+</robot>

--- a/IndyAV/simulation/indyav_gazebo/urdf/fixed_link_persistent.xacro
+++ b/IndyAV/simulation/indyav_gazebo/urdf/fixed_link_persistent.xacro
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro  name="fixed_link_persistent"
+                params="name parent='base_link'
+                        xyz:='0 0 0' rpy:='0 0 0'">
+    <gazebo>
+      <link name="${name}" />
+      <joint name="${name}_to_${parent}" type="fixed">
+        <parent>${parent}</parent>
+        <child>${child}</child>
+        <pose>${xyz} ${rpy}</pose>
+      </joint>
+    </gazebo>
+    <link name="${name}" />
+    <joint name="${name}_to_${parent}" type="fixed">
+      <parent link="${parent}" />
+      <child link="${name}" />
+      <origin xyz="${xyz}" rpy="${rpy}" />
+    </joint>
+  </xacro:macro>
+</robot>

--- a/IndyAV/simulation/indyav_gazebo/urdf/indyav_car.urdf.xacro
+++ b/IndyAV/simulation/indyav_gazebo/urdf/indyav_car.urdf.xacro
@@ -3,10 +3,7 @@
   <xacro:include filename="$(find indyav_gazebo)/xacro/go_kart.xacro"/>
   <xacro:include filename="$(find indyav_gazebo)/xacro/wheels.xacro"/>
   <xacro:include filename="$(find indyav_gazebo)/urdf/sensors/sylphase.xacro"/>
-  <!-- 9/9/20: On line above, replaced 
-  $(find wamv_gazebo)/urdf/sensors/wamv_p3d with 
-  $(find indy_gazebo)/urdf/sensors/sylphase.xacro-->
-   <!-- 9/9/20: Created sensors directory within urdf/ and placed sylphase.xacro there-->
+  
   <link name="base_link">
     <xacro:body_inertial/>
     <visual>

--- a/IndyAV/simulation/indyav_gazebo/urdf/indyav_car.urdf.xacro
+++ b/IndyAV/simulation/indyav_gazebo/urdf/indyav_car.urdf.xacro
@@ -2,8 +2,11 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="indyav_car">
   <xacro:include filename="$(find indyav_gazebo)/xacro/go_kart.xacro"/>
   <xacro:include filename="$(find indyav_gazebo)/xacro/wheels.xacro"/>
-  <xacro:include filename="$(find wamv_gazebo)/urdf/sensors/wamv_p3d.xacro"/>
-
+  <xacro:include filename="$(find indyav_gazebo)/urdf/sensors/sylphase.xacro"/>
+  <!-- 9/9/20: On line above, replaced 
+  $(find wamv_gazebo)/urdf/sensors/wamv_p3d with 
+  $(find indy_gazebo)/urdf/sensors/sylphase.xacro-->
+   <!-- 9/9/20: Created sensors directory within urdf/ and placed sylphase.xacro there-->
   <link name="base_link">
     <xacro:body_inertial/>
     <visual>

--- a/IndyAV/simulation/indyav_gazebo/urdf/sensors/sylphase.xacro
+++ b/IndyAV/simulation/indyav_gazebo/urdf/sensors/sylphase.xacro
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro  name="sylphase"
+                params="name='ins'
+                        xyz:='0 0 0' rpy:='0 0 0'">
+    <xacro:include filename="$(find indy_gazebo)/urdf/fixed_link_persistent.xacro" />
+    <link name="${name}">
+    </link>
+    <gazebo reference="${name}">
+      <sensor name="${name}_imu" type="imu" />
+      <sensor name="${name}_gps" type="gps" />
+    </gazebo>
+    <joint name="${name}_to_base_link" type="fixed">
+      <parent link="base_link" />
+      <child link="${name}" />
+      <origin xyz="${xyz}" rpy="${rpy}" />
+    </joint>
+    <gazebo>
+      <plugin name="sylphase_plugin" filename="libsylphase_gazebo.so">
+        <pose>${xyz} ${rpy}</pose>
+        <child_frame>${name}</child_frame>
+        <odom_topic>ins_odom</odom_topic>
+      </plugin>
+    </gazebo>
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
In the indyav_car.urdf.xacro file, the extension that had the p3d sensor was modified to use the sylphase sensor instead. Using the navigator_urdf.xacro file as a reference, I also created a sensors directory within the /urdf folder, and within it contains a modified sylphase.xacro file for the indyav_gazebo. Also within the /urdf directory I included two more .xacro files, fixed_link_persistent.xacro and fixed_link.xacro, as they were included in the navigator_gazebo as well.