### PR TITLE
INDYAV: revised implementation for joydrive utility

### DIFF
--- a/IndyAV/command/indyav_launch/launch/controls.launch
+++ b/IndyAV/command/indyav_launch/launch/controls.launch
@@ -9,7 +9,7 @@
       args="car/simulated_hardware_controllers/steering/left
             car/simulated_hardware_controllers/steering/right
             joint_state_publisher"/>
-    <node name="simualted_steering_driver" pkg="indyav_control" type="simulated_steering_driver"
+    <node name="simulated_steering_driver" pkg="indyav_control" type="simulated_steering_driver"
       respawn="true">
       <param name="input_topic" value="/steering"/>
     </node>

--- a/IndyAV/command/indyav_launch/launch/joydrive.launch
+++ b/IndyAV/command/indyav_launch/launch/joydrive.launch
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<launch>
+
+ <!-- Joystick Driver -->
+  <arg name="js" default="js0"/>
+  <node pkg="joy" type="joy_node" name="joy" output="screen">
+   <param name="dev" value="/dev/input/$(arg js)"/>
+   <param name="autorepeat_rate" value="10"/>
+  </node>
+
+ <!--Joystick Teleop-->
+ <node pkg="indyav_control" type="joy_teleop" name="joy_teleop" output="screen">
+  <param name="axis_steer" value="0" type="int"/>
+  <param name="axis_throttle" value="5" type="int"/>
+  <param name="scale_steer" value="0.785398" type="double"/>
+  <param name="scale_trigger" value="74.9906262" type="double"/>
+  <param name="throttle_topic" value="/throttle"/>
+  <param name="steering_topic" value="/steering"/>
+ </node>
+
+</launch>

--- a/IndyAV/command/indyav_launch/package.xml
+++ b/IndyAV/command/indyav_launch/package.xml
@@ -13,6 +13,7 @@
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>indyav_localization</exec_depend>
   <exec_depend>indyav_control</exec_depend>
+  <exec_depend>joy</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>indyav_gazebo</exec_depend>
   <buildtool_depend>catkin</buildtool_depend>

--- a/IndyAV/control/indyav_control/CMakeLists.txt
+++ b/IndyAV/control/indyav_control/CMakeLists.txt
@@ -68,8 +68,13 @@ add_dependencies(simulated_steering_driver
   std_msgs
   ${catkin_EXPORTED_TARGETS})
 target_link_libraries(simulated_steering_driver
-  ${catkin_LIBRARIES}
-)
+  ${catkin_LIBRARIES})
+add_executable(joy_teleop 
+  src/joy_teleop.cpp)
+add_dependencies(joy_teleop
+  ${catkin_EXPORTED_TARGETS})
+target_link_libraries(joy_teleop 
+  ${catkin_LIBRARIES})
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the

--- a/IndyAV/control/indyav_control/src/joy_teleop.cpp
+++ b/IndyAV/control/indyav_control/src/joy_teleop.cpp
@@ -1,0 +1,112 @@
+#include <geometry_msgs/Twist.h>
+#include <indyav_control/RevsStamped.h>
+#include <indyav_control/SteeringStamped.h>
+
+#include <sstream>
+#include <string>
+
+#include "ros/ros.h"
+#include "sensor_msgs/Joy.h"
+
+class JoyTeleop
+{
+public:
+  JoyTeleop(ros::NodeHandle* _nh);
+
+private:
+  void Callback(const sensor_msgs::Joy::ConstPtr& joy);
+
+  ros::NodeHandle* nh_;
+
+  int steer_axis_, throttle_axis_;
+  double s_scale_, r_scale_;
+  std::string t_advertise_, s_advertise_;
+  ros::Subscriber joy_;
+  ros::Publisher steering_pub_, throttle_pub_;
+};
+
+JoyTeleop::JoyTeleop(ros::NodeHandle* _nh)
+{
+  nh_ = _nh;
+
+  if (nh_->getParam("axis_steer", steer_axis_))
+  {
+    ROS_INFO("Got param 'axis_steer': %d", steer_axis_);
+  }
+  else
+  {
+    ROS_ERROR("Failed to get param 'axis_steer'");
+  }
+  if (nh_->getParam("axis_throttle", throttle_axis_))
+  {
+    ROS_INFO("Got param 'axis_throttle': %d", throttle_axis_);
+  }
+  else
+  {
+    ROS_ERROR("Failed to get param 'axis_throttle'");
+  }
+  if (nh_->getParam("scale_steer", s_scale_))
+  {
+    ROS_INFO("Got param 'scale_steer': %f", s_scale_);
+  }
+  else
+  {
+    ROS_ERROR("Failed to get param 'scale_steer'");
+  }
+  if (nh_->getParam("scale_trigger", r_scale_))
+  {
+    ROS_INFO("Got param 'scale_trigger': %f", r_scale_);
+  }
+  else
+  {
+    ROS_ERROR("Failed to get param 'scale_trigger'");
+  }
+  if (nh_->getParam("throttle_topic", t_advertise_))
+  {
+    ROS_INFO("Got param 'throttle_topic': %s", t_advertise_.c_str());
+  }
+  else
+  {
+    ROS_ERROR("Failed to get param 'throttle_topic'");
+  }
+  if (nh_->getParam("steering_topic", s_advertise_))
+  {
+    ROS_INFO("Got param 'steering_topic': %s", s_advertise_.c_str());
+  }
+  else
+  {
+    ROS_ERROR("Failed to get param 'steering_topic'");
+  }
+
+  throttle_pub_ = nh_->advertise<indyav_control::RevsStamped>(t_advertise_, 1);
+  steering_pub_ = nh_->advertise<indyav_control::SteeringStamped>(s_advertise_, 1);
+  joy_ = nh_->subscribe<sensor_msgs::Joy>("/joy", 100, &JoyTeleop::Callback, this);
+}
+
+void JoyTeleop::Callback(const sensor_msgs::Joy::ConstPtr& _joy)
+{
+  static indyav_control::RevsStamped radians_per_second;
+  static indyav_control::SteeringStamped steering_angle;
+
+  steering_angle.steering_angle = s_scale_ * _joy->axes.at(steer_axis_);
+
+  // Gamepad trigger incorrectly defaults to 0 when resting position is 1. Moving the trigger updates the value,
+  // correcting the error. To seamlessly work around the problem, the angular velocity is not assigned until this change
+  // is detected.
+  static bool gamepad_init = false;
+  if (_joy->axes.at(throttle_axis_) != 0)
+    gamepad_init = true;
+  if (gamepad_init)
+    radians_per_second.radians_per_second = r_scale_ * (abs(_joy->axes.at(throttle_axis_) - 1)) / 2;
+
+  steering_pub_.publish(steering_angle);
+  throttle_pub_.publish(radians_per_second);
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "joy_teleop");
+  ros::NodeHandle nh("~");
+  JoyTeleop joy_teleop(&nh);
+  ros::spin();
+}

--- a/IndyAV/control/indyav_control/src/simulated_steering_driver.cpp
+++ b/IndyAV/control/indyav_control/src/simulated_steering_driver.cpp
@@ -12,7 +12,7 @@ SimulatedSteeringDriver<MSG>::SimulatedSteeringDriver(ros::NodeHandle* _nh, cons
   std::string name = "/car";
   ROS_ASSERT_MSG(ros::param::has(name), "no car param namspace");
   name += "/simulated_hardware_controllers";
-  ROS_ASSERT_MSG(nh_->hasParam(name), "no simualted hardware controllers param namspace");
+  ROS_ASSERT_MSG(nh_->hasParam(name), "no simulated hardware controllers param namspace");
   name += "/steering";
   ROS_ASSERT_MSG(nh_->hasParam(name), "no steering param namspace");
 

--- a/docs/indyav/software/control/control.rst
+++ b/docs/indyav/software/control/control.rst
@@ -1,6 +1,11 @@
 Control
 =======
 
+.. toctree::
+    :maxdepth: 1
+
+    IndyAV Joydrive <joydrive/joydrive.rst>
+
 Control Packages
 ----------------
 No software developed yet.

--- a/docs/indyav/software/control/joydrive/joydrive.rst
+++ b/docs/indyav/software/control/joydrive/joydrive.rst
@@ -1,0 +1,45 @@
+IndyAV Joydrive Utility
+=======================
+
+
+How to Use
+----------
+
+Setting up an Xbox 360 controller
+*********************************
+``roslaunch indyav_launch gazebo.launch``
+
+Plug in the controller and check to see if it is recognized.
+``ls /dev/input/``
+This outputs a list of input devices in the format shown below::
+
+    by-id    event0  event2  event4  event6  event8  mouse0  mouse2  uinput
+    by-path  event1  event3  event5  event7  js0     mice    mouse1
+
+Joysticks will be listed as jsX.
+
+Running the utility
+*******************
+Launch the Joydrive.
+``roslaunch indyav_launch joydrive.launch``
+By default, js0 is used by the joydrive utility. To change the input device, pass the name of the input device using the "js" argument.
+``roslaunch indyav_launch joydrive.launch js:=js1``
+
+In a new panel, launch Gazebo for IndyAV.
+``roslaunch indyav_launch gazebo.launch``
+
+In a new panel, launch RVIZ for IndyAV.
+``indyviz``
+
+In a new panel, launch the Gazebo Client.
+``gazebogui``
+
+Using the utility
+*****************
+Moving the left joystick left and right steers the car.
+
+Depressing the right trigger accelerates the car. Releasing the trigger brakes the car.
+
+Optionally, one can view the values for the wheel velocity and steering angle by running the following in new panels:
+``rostopic echo /throttle``
+``rostopic echo /steering``

--- a/docs/indyav/software/software.rst
+++ b/docs/indyav/software/software.rst
@@ -12,7 +12,7 @@ because of the speed of the vehicle.
    :maxdepth: 1
    :caption: Elements of Autonomony
 
-   Control <control>
+   Control <control/control.rst>
    Localization <localization>
    Perception <perception>
    Planning <planning/planning.rst>


### PR DESCRIPTION
**Setting up an Xbox 360 controller**
Plug in the controller and check to see if it is recognized.
`ls /dev/input/`
This outputs a list of input devices in the format shown below:
```
by-id    event0  event2  event4  event6  event8  mouse0  mouse2  uinput
by-path  event1  event3  event5  event7  js0     mice    mouse1
```
Joysticks will be listed as jsX.

**Running the utility**
Launch the Joydrive.
`roslaunch indyav_launch joydrive.launch`
By default, js0 is used by the joydrive utility. To use a different input device, pass the name of the input device using the "js" argument.
`roslaunch indyav_launch joydrive.launch js:=js1`

In a new panel, launch Gazebo for IndyAV.
`roslaunch indyav_launch gazebo.launch`

In a new panel, launch RVIZ for IndyAV.
`indyviz`

In a new panel, launch the Gazebo Client.
`gazebogui`

**Using the utility**

Moving the left joystick left and right steers the car.

Depressing the right trigger accelerates the car. Releasing the trigger brakes the car.

Optionally, one can view the values for the wheel velocity and steering angle by running the following in new panels:
`rostopic echo /throttle`
`rostopic echo /steering`