### PR TITLE
Update setup scripts for ROS Noetic

### DIFF
--- a/NaviGator/scripts/bash_aliases.sh
+++ b/NaviGator/scripts/bash_aliases.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Directory navigation
-NAV_DIR="$(realpath $(dirname $BASH_SOURCE)/..)"
+NAV_DIR="$HOME/catkin_ws/src/mil/NaviGator"
 alias nav="cd $NAV_DIR"
 # VRX
 alias vrxviz="rviz -d \$MIL_REPO/NaviGator/vrx.rviz"

--- a/SubjuGator/scripts/bash_aliases.sh
+++ b/SubjuGator/scripts/bash_aliases.sh
@@ -8,7 +8,7 @@
 
 # Directory navigation
 
-CATKIN_DIR="$(realpath $(dirname $BASH_SOURCE)/../../../../)"
+CATKIN_DIR="$HOME/catkin_ws"
 
 alias sub="cd \$CATKIN_DIR/src/mil/SubjuGator"
 

--- a/docker/base/system_install
+++ b/docker/base/system_install
@@ -13,18 +13,22 @@ sudo apt update
 mil_system_install apt-utils
 mil_system_install --no-install-recommends \
   ca-certificates \
+  curl \
   tzdata \
   dirmngr \
   gnupg2 \
   lsb-release \
-  python-vcstools \
-  python-pip \
+  python2 \
+  python3-vcstool \
   ruby \
   wget \
   expect
 
-# Other dependencies
-sudo sh -c "pip install numpy"
+# Install Python 2 pip
+sudo add-apt-repository universe
+sudo apt update
+curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+python2 get-pip.py
 
 # ROS apt source
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
@@ -41,45 +45,43 @@ wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 # Update apt again and install ros
 sudo apt update
 
-mil_system_install ros-melodic-desktop-full
+mil_system_install ros-noetic-desktop-full
 # Install additional dependencies not bundled by default with ros
 # Please put each on a new line for readability
 mil_system_install \
-  ros-melodic-serial \
-  ros-melodic-tf2-sensor-msgs \
-  ros-melodic-geographic-msgs \
-  ros-melodic-velodyne \
-  ros-melodic-usb-cam \
-  ros-melodic-joy \
-  ros-melodic-spacenav-node \
-  ros-melodic-velodyne-simulator \
-  ros-melodic-hector-gazebo-plugins \
-  ros-melodic-joy \
-  ros-melodic-joy-teleop \
-  ros-melodic-key-teleop \
-  ros-melodic-robot-localization \
-  ros-melodic-teleop-tools \
-  ros-melodic-teleop-twist-keyboard \
-  ros-melodic-ros-control \
-  ros-melodic-ros-controllers \
-  python-pip \
-  clang-format-3.9
-sudo pip install \
-  tqdm \
-  scipy \
-  sklearn \
-  pandas
+  ros-noetic-serial \
+  ros-noetic-tf2-sensor-msgs \
+  ros-noetic-geographic-msgs \
+  ros-noetic-velodyne \
+  ros-noetic-usb-cam \
+  ros-noetic-joy \
+  ros-noetic-spacenav-node \
+  ros-noetic-velodyne-simulator \
+  ros-noetic-hector-gazebo-plugins \
+  ros-noetic-joy-teleop \
+  ros-noetic-key-teleop \
+  ros-noetic-robot-localization \
+  ros-noetic-teleop-tools \
+  ros-noetic-teleop-twist-keyboard \
+  ros-noetic-ros-control \
+  ros-noetic-ros-controllers \
 
 # Documentation dependencies
 mil_system_install  python3-pip
 
+# Install Python 3 ROS node dependencies
 sudo pip3 install -q \
   sphinx \
   recommonmark \
   sphinx_rtd_theme \
   numpy \
-  matplotlib
+  matplotlib \
+  tqdm \
+  scipy \
+  sklearn \
+  pandas
 
 # Initialize rosdep
-sudo pip install -U rosdep
+sudo apt-get install python3-rosdep
 sudo rosdep init
+sudo rosdep update

--- a/docker/dev/user_install
+++ b/docker/dev/user_install
@@ -30,22 +30,35 @@ mil_user_install_dependencies()
 
 # Add line to user's bashrc which source the repo's setup files
 # This allows us to update aliases, environment variables, etc
-mil_user_setup_bashrc()
+mil_user_setup_rc()
 {
-  # Line(s) added to ~/.bashrc
+  # Line(s) added to ~/.bashrc or ~/.zshrc
   # Note that for backwards compatiblity this should not be changed
   # unless you have a very good reason.
   BASH_RC_LINES=". $MIL_REPO_DIR/scripts/setup.bash"
-
-  # Add the line(s) to bashrc if not already present
-  if grep -Fq "$BASH_RC_LINES" ~/.bashrc
+  if [[ "$SHELL" == "/usr/bin/zsh" ]]
   then
-    echo "milrc is already sourced in ~/.bashrc, skipping"
+    # User is using zsh
+    if grep -Fq "$BASH_RC_LINES" ~/.zshrc
+    then
+        echo "milrc is already sourced in ~/.zshrc, skipping"
+    else
+        echo "Adding source of milrc to ~/.zshrc"
+        echo "" >> ~/.zshrc
+        echo "# Setup enviroment for MIL developement" >> ~/.zshrc
+        echo "$BASH_RC_LINES" >> ~/.zshrc
+    fi
   else
-    echo "Adding source of milrc to ~/.bashrc"
-    echo "" >> ~/.bashrc
-    echo "# Setup enviroment for MIL developement" >> ~/.bashrc
-    echo "$BASH_RC_LINES" >> ~/.bashrc
+    # User is using zsh
+    if grep -Fq "$BASH_RC_LINES" ~/.bashrc
+    then
+        echo "milrc is already sourced in ~/.bashrc, skipping"
+    else
+        echo "Adding source of milrc to ~/.bashrc"
+        echo "" >> ~/.bashrc
+        echo "# Setup enviroment for MIL developement" >> ~/.bashrc
+        echo "$BASH_RC_LINES" >> ~/.bashrc
+    fi
   fi
 }
 
@@ -59,8 +72,12 @@ mil_user_setup_init_catkin()
 }
 
 mil_user_install_dependencies
-mil_user_setup_bashrc
+mil_user_setup_rc
 set +u
-. /opt/ros/melodic/setup.bash
+if [ "$SHELL" = "/usr/bin/zsh" ]; then
+  . /opt/ros/noetic/setup.zsh
+else
+  . /opt/ros/noetic/setup.bash
+fi
 set -u
 mil_user_setup_init_catkin

--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -1,12 +1,19 @@
 #!/bin/bash
 export MIL_CONFIG_DIR=$HOME/.mil
 mkdir -p $MIL_CONFIG_DIR
-export MIL_WS="$(realpath $(dirname $BASH_SOURCE)/../../..)"
+export MIL_WS="$HOME/catkin_ws"
 MIL_REPO="$MIL_WS/src/mil"
 
 # Source ROS and local catkin
-source /opt/ros/melodic/setup.bash
-source $MIL_WS/devel/setup.bash
+if [[ "$SHELL" == "/usr/bin/zsh" ]]
+then
+    source /opt/ros/noetic/setup.zsh
+    source $MIL_WS/devel/setup.zsh
+else
+    source /opt/ros/noetic/setup.bash
+    source $MIL_WS/devel/setup.bash
+fi
+
 
 # Script tools
 # Helper for autocompleting given a list of choices for the first argument


### PR DESCRIPTION
The setup scripts (`.../scripts/system_install` and `.../scripts/user_install`) have been updated with the following features:

- Support for `zsh` and `.zsh` ROS files
- Support for installing `ros-noetic` apt packages
- Support for installing Python 3 dependencies

Closes #396, closes #397.