### PR TITLE
Migrate `navigator_msg_multiplexer` package from Python 2 to Python 3

### DIFF
--- a/NaviGator/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
+++ b/NaviGator/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
@@ -79,21 +79,38 @@ def transform_enu_to_ogrid(enu_points: List[List[int]], grid: OccupancyGrid) -> 
     t = make_ogrid_transform(grid)
     return t.dot(np.array(enu_points_np).T).T
 
-def transform_ogrid_to_enu(grid_points, grid):
+def transform_ogrid_to_enu(grid_points: List[List[int]], grid: OccupancyGrid) -> np.ndarray:
     """
-    Converts an ogrid cell into the enu frame.
-    `grid_points` should be a list of points in the ogrid frame that will be converted
-        into the ENU frame
-    """
-    grid_points = np.array(grid_points)
+    Converts an ogrid cell into the ENU frame.
 
-    if grid_points.size > 3:
-        grid_points[:, 2] = 1
+    Args:
+        grid_points: List[List[int]] - A list of ogrid points that
+        will be converted to the ENU frame.
+        grid: OccupancyGrid - The occupancy grid representing the ENU frame.
+
+    Returns:
+        np.ndarray - ???
+    """
+    grid_points_np = np.array(grid_points)
+
+    if grid_points_np.size > 3:
+        grid_points_np[:, 2] = 1
 
     t = np.linalg.inv(make_ogrid_transform(grid))
-    return t.dot(np.array(grid_points).T).T
+    return t.dot(np.array(grid_points_np).T).T
 
-def transform_between_ogrids(grid1_points, grid1, grid2):
+def transform_between_ogrids(grid1_points: List[List[int]], grid1: OccupancyGrid, grid2: OccupancyGrid) -> np.ndarray:
+    """
+    ???
+
+    Args:
+        grid1_points: List[List[int]] - ???
+        grid1: OccupancyGrid - ???
+        grid2: OccupancyGrid - ???
+
+    Returns:
+        np.ndarray - ???
+    """
     enu = transform_ogrid_to_enu(grid1_points, grid1)
     return transform_enu_to_ogrid(enu, grid2)
 
@@ -201,6 +218,12 @@ class OGridServer:
 
         Used by the subscriber to /odom as a callback in order to parse
         and store received messages.
+
+        Args:
+            msg: Odometry - The message from the /odom topic
+
+        Returns:
+            np.ndarray - The converted pose in a numpy array.
         """
         return setattr(self, 'odom', mil_tools.pose_to_numpy(msg.pose.pose))
 

--- a/NaviGator/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
+++ b/NaviGator/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
@@ -59,7 +59,7 @@ def numpyify(ogrid: OccupancyGrid) -> np.array:
     """
     return np.array(ogrid.data).reshape(ogrid.info.height, ogrid.info.width)
 
-def transform_enu_to_ogrid(enu_points: List[List[int]], grid: OccupancyGrid) -> np.ndarray:
+def transform_enu_to_ogrid(enu_points: List[int], grid: OccupancyGrid) -> np.ndarray:
     """
     Converts an ENU point into the global ogrid's frame.
 
@@ -79,7 +79,7 @@ def transform_enu_to_ogrid(enu_points: List[List[int]], grid: OccupancyGrid) -> 
     t = make_ogrid_transform(grid)
     return t.dot(np.array(enu_points_np).T).T
 
-def transform_ogrid_to_enu(grid_points: List[List[int]], grid: OccupancyGrid) -> np.ndarray:
+def transform_ogrid_to_enu(grid_points: List[int], grid: OccupancyGrid) -> np.ndarray:
     """
     Converts an ogrid cell into the ENU frame.
 
@@ -99,7 +99,7 @@ def transform_ogrid_to_enu(grid_points: List[List[int]], grid: OccupancyGrid) ->
     t = np.linalg.inv(make_ogrid_transform(grid))
     return t.dot(np.array(grid_points_np).T).T
 
-def transform_between_ogrids(grid1_points: List[List[int]], grid1: OccupancyGrid, grid2: OccupancyGrid) -> np.ndarray:
+def transform_between_ogrids(grid1_points: List[int], grid1: OccupancyGrid, grid2: OccupancyGrid) -> np.ndarray:
     """
     ???
 
@@ -457,9 +457,16 @@ class OGridServer:
 
     def plow_snow(self, np_grid: np.ndarray, ogrid: OccupancyGrid) -> np.ndarray:
         """
-        Remove region around the boat so we never touch an occupied cell (making lqrrt not break
-        if something touches us).
+        Remove region around the boat so we never touch an occupied cell
+        (making lqrrt not break if something touches us). If the boat's location
+        is not known, then the np_grid argument is returned.
 
+        Args:
+            np_grid: np.ndarray - ???
+            ogrid: OccupancyGrid - ???
+
+        Returns:
+            np.ndarray - ???
         """
         if self.odom is None:
             return np_grid
@@ -488,7 +495,7 @@ class OGridServer:
         h = boat_height / ogrid.info.resolution
 
         box = cv2.boxPoints(((x, y), (w, h), np.degrees(theta)))
-        box = np.intp(box)
+        box = np.int0(box)
         cv2.drawContours(np_grid, [box], 0, 40, -1)
 
         return np_grid

--- a/NaviGator/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
+++ b/NaviGator/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#! /usr/bin/python3
 from __future__ import division
 
 import rospy
@@ -23,10 +23,17 @@ from navigator_path_planner import params
 fprint = lambda *args, **kwargs: _fprint(title="OGRID_ARB", *args, **kwargs)
 
 
-def make_ogrid_transform(ogrid):
+def make_ogrid_transform(ogrid: OccupancyGrid) -> np.array:
     """
     Returns a matrix that transforms a point in ENU to this ogrid.
     Invert the result to get ogrid -> ENU.
+
+    Args:
+        ogrid: OccupancyGrid - The occupancy grid to make a transform of.
+
+    Returns:
+        A numpy array (np.array) representing an ogrid
+        with a transformed ENU.
     """
     resolution = ogrid.info.resolution
     origin = mil_tools.pose_to_numpy(ogrid.info.origin)[0]
@@ -37,11 +44,18 @@ def make_ogrid_transform(ogrid):
                   [0, 0, 1]])
     return t
 
+def numpyify(ogrid: OccupancyGrid) -> np.array:
+    """
+    Converts an occupancy grid to a pure numpy array.
 
-def numpyify(ogrid):
-    # Could be a lambda
+    Args:
+        ogrid: OccupancyGrid - The occupancy grid to convert.
+
+    Returns:
+        A numpy array (np.array) representing the original
+        ogrid.
+    """
     return np.array(ogrid.data).reshape(ogrid.info.height, ogrid.info.width)
-
 
 def transform_enu_to_ogrid(enu_points, grid):
     """
@@ -57,7 +71,6 @@ def transform_enu_to_ogrid(enu_points, grid):
     t = make_ogrid_transform(grid)
     return t.dot(np.array(enu_points).T).T
 
-
 def transform_ogrid_to_enu(grid_points, grid):
     """
     Converts an ogrid cell into the enu frame.
@@ -72,11 +85,9 @@ def transform_ogrid_to_enu(grid_points, grid):
     t = np.linalg.inv(make_ogrid_transform(grid))
     return t.dot(np.array(grid_points).T).T
 
-
 def transform_between_ogrids(grid1_points, grid1, grid2):
     enu = transform_ogrid_to_enu(grid1_points, grid1)
     return transform_enu_to_ogrid(enu, grid2)
-
 
 def get_enu_corners(grid):
     """
@@ -86,7 +97,6 @@ def get_enu_corners(grid):
     _min = grid_to_enu.dot([0, 0, 1])
     _max = grid_to_enu.dot([grid.info.height, grid.info.width, 1])
     return (_min, _max)
-
 
 class OGrid:
     def __init__(self, topic, replace=False, frame_id='enu'):
@@ -111,7 +121,6 @@ class OGrid:
         self.last_message_stamp = ogrid.header.stamp
         self.nav_ogrid = ogrid
         self.np_map = numpyify(ogrid)
-
 
 class OGridServer:
     def __init__(self, frame_id='enu', map_size=500, resolution=0.3, rate=1):
@@ -369,7 +378,6 @@ class OGridServer:
 
         # fprint("Plowed snow!")
         return np_grid
-
 
 if __name__ == '__main__':
     rospy.init_node('ogrid_server', anonymous=False)


### PR DESCRIPTION
The first package to be migrated as part of the ROS Noetic migration!

Includes more typing support and function docstrings. Most of the core code was unchanged.

Closes #389.