### PR TITLE
Created bash files kill_ros.sh and kill_process.sh for cleanup

### DIFF
--- a/scripts/kill_process.sh
+++ b/scripts/kill_process.sh
@@ -1,0 +1,35 @@
+
+# !/bin/bash
+
+
+echo What keyword would you like to delete?
+read word < /dev/tty
+pgrep -f "$word" > ptkword.txt
+
+echo Would you like to kill all processes? [Y/N]
+read killall < /dev/tty
+
+
+while read p; do
+        case "$killall" in
+         y|Y ) kill -9 $p;;
+         n|N ) ;;
+        esac
+done<ptkword.txt
+sleep 1
+
+pgrep -f "$word" > ptkword.txt
+
+while read p; do
+        echo Do you want to delete $p ? [Y/N]
+        read answer < /dev/tty
+        echo you responded $answer
+
+        case "$answer" in
+         y|Y ) kill -9 $p;;
+         n|N ) echo "NO";;
+        esac
+done<ptkword.txt
+rm ptkword.txt
+
+echo "Clean up finished :)"

--- a/scripts/kill_process.sh
+++ b/scripts/kill_process.sh
@@ -2,11 +2,11 @@
 # !/bin/bash
 
 
-echo What keyword would you like to delete?
+echo Enter keyword to delete
 read word < /dev/tty
 pgrep -f "$word" > ptkword.txt
 
-echo Would you like to kill all processes? [Y/N]
+echo Kill all processes that contain: "$word" ? [Y/N]
 read killall < /dev/tty
 
 
@@ -21,9 +21,10 @@ sleep 1
 pgrep -f "$word" > ptkword.txt
 
 while read p; do
-        echo Do you want to delete $p ? [Y/N]
+
+	pname=$(ps -p $p -o comm=)
+        echo Delete $pname ? [Y/N]
         read answer < /dev/tty
-        echo you responded $answer
 
         case "$answer" in
          y|Y ) kill -9 $p;;

--- a/scripts/kill_ros.sh
+++ b/scripts/kill_ros.sh
@@ -1,0 +1,35 @@
+# !/bin/bash
+
+rosnode kill --all
+pgrep -f "gazebo" > ptk.txt
+pgrep -f  "rosmaster" >> ptk.txt
+
+echo Kill all processes? [Y/N]
+read killall < /dev/tty
+
+
+while read p; do
+	case "$killall" in
+	 y|Y ) kill -9 $p;;
+	 n|N ) ;;
+	esac
+done<ptk.txt
+sleep 1
+pgrep -f "gazebo" > ptk.txt
+pgrep -f "rosmaster" >> ptk.txt
+
+
+
+while read p; do
+	pname=$(ps -p $p -o comm=)
+	echo Delete $pname ? [Y/N]
+	read answer < /dev/tty
+
+	case "$answer" in
+	 y|Y ) kill -9 $p;;
+	 n|N ) echo "NO";;
+	esac
+done<ptk.txt
+rm ptk.txt
+echo "Clean up finished :)"
+

--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -90,3 +90,6 @@ alias killgazebo="killall -9 gzserver && killall -9 gzclient"
 # Aliases for switching between branches
 alias master2vrx="$MIL_REPO/scripts/master_to_vrx.sh"
 alias vrx2master="$MIL_REPO/scripts/vrx_to_master.sh"
+
+alias killros="$MIL_REPO/scripts/kill_ros.sh"
+alias killprocess="$MIL_REPO/scripts/kill_process.sh"


### PR DESCRIPTION
This fixes the issue of straggling process and nodes being left over after an ungraceful stop to ROS. By deleting every process with "rosmaster" or "gazebo", the engineer can just run the "killros" alias to clean up.

This can be tested by running 
`roslaunch navigator_launch vrx.launch run_task:=True world:=stationkeeping_task --screen`
and using `ctrl + \` to simulate an ungraceful stop.

Use `ps aux | grep -f 'gazebo` and `ps aux | grep -f 'rosmaster` to see unkilled processes.

Now, use the alias `killros` to select which processes you want to delete, if not all of them.

try launching ros after this, it will run correctly.