### PR TITLE
Add Git credential manager

### DIFF
--- a/docs/development/getting_started.md
+++ b/docs/development/getting_started.md
@@ -65,6 +65,13 @@ Exit the terminal and enter it again.
 
 *NOTE: now the MIL aliases will work on your machine. You can type* `mil` *to take you to the root of the repo anytime*
 
+### Configuring Git
+
+If you have not configured Git to use your name/email on your new Ubuntu setup, you can use the script below to set up your Git configuration! It will help you register your name and email with Git and authenticate so that you can push to the repository.
+
+```
+$ ./scripts/store_git.sh
+```
 
 ### Starting a tmux session in the development container
 When using ROS and Gazebo, many terminals are required. [tmux](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) is a program which allows one terminal to be split into many terminals each called a panel. We highly recommend its use when runnning code, esspecially when working in a docker container.

--- a/scripts/store_git.sh
+++ b/scripts/store_git.sh
@@ -55,4 +55,89 @@ This script will help you:
 1. Store your Git name/email if not already set
 2. Download libcrypt, a secure library for storing Git credentials
 3. Help you create a personal access token for Git authentication
+
 EOF
+
+read -r -p "$(color $Gre)Ready to start? [y/N] " response
+case "$response" in
+    [yY][eE][sS]|[yY]) 
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+
+clear
+#GitName="$(git config --global user.name)"
+GitName=""
+GitEmail="$(git config --global user.email)"
+GitFixNeeded=0
+
+if [ "$GitName" != "" ]
+then
+cat << EOF
+$(hash_header)
+$(color $Yel)You appear to have your Git name/email setup. Are the following
+values correct? The name should be your first name, followed by your last name. 
+The email shown below should be linked to your GitHub account.
+
+    $(color $Pur)Name: ${GitName}
+    Email: ${GitEmail}
+
+EOF
+read -r -p "$(color $Gre)Are the values correct? [y/N] " response
+case "$response" in
+    [yY][eE][sS]|[yY]) 
+        ;;
+    *)
+        clear
+        echo $(hash_header)
+        GitFixNeeded=1
+        ;;
+esac
+else
+cat << EOF
+$(hash_header)
+$(color $Yel)You do not have your Git name/email set up. These values are used
+to link your commits to you and your GitHub account.
+
+EOF
+GitFixNeeded=1
+fi
+
+if [ $GitFixNeeded = 1 ]
+then
+cat << EOF
+$(color $Yel)Enter your Git credentials below.
+
+EOF
+
+Done=1
+while [ $Done = 1 ]
+do
+    read -r -p "$(color $Gre)Enter your name (First Last): " GitNameResponse
+    read -r -p "$(color $Gre)Enter your email: " GitEmailResponse
+
+cat << EOF
+$(color $Yel)Please verify that the values below are correct for your name
+and email.
+
+    Name: ${GitNameResponse}
+    Email: ${GitEmailResponse}
+
+EOF
+read -r -p "$(color $Gre)Are the values correct? [y/N] " GitNameVerifyResponse
+case "$GitNameVerifyResponse" in
+    [yY][eE][sS]|[yY]) 
+        clear
+        echo $(hash_header)
+        echo $(color $Gre)The values have been saved. Proceeding to the next step in 5 seconds.
+        sleep 5;
+        Done=0
+        ;;
+    *)
+        ;;
+esac
+done
+
+fi

--- a/scripts/store_git.sh
+++ b/scripts/store_git.sh
@@ -53,7 +53,7 @@ quickly and securely.
 
 This script will help you:
 1. Store your Git name/email if not already set
-2. Download libcrypt, a secure library for storing Git credentials
+2. Download gh, the CLI interface to GitHub
 3. Help you create a personal access token for Git authentication
 
 EOF
@@ -196,19 +196,20 @@ cat << EOF
 $(hash_header)
 $(color $Yel)You will now generate a personal access token (PAT).
 
-Follow the steps below:
-1. Sign into https://github.com.
-2. In the top right corner, click on your profile, and then Settings.
-3. On the left sidebar, click Developer Settings.
-4. On the left sidebar again, click on Personal Access Tokens.
-5. Near the top, click Generate Token and enter your password again.
-6. Set the Note to explain what the token is being used for (such as your VM)
-   and set the expiration time to whatever you would like. Whenever the token
-   expires, you will need to run this script again and re-authenticate.
-7. Select all checkboxes under the Permissions section of your new token.
-8. Click Generate Token and copy the new token.
-   $(color $Red)Do not refresh the page or the token will disappear!
+A web browser will open that allows you to create a new token. You should just
+need to click Generate Token at the bottom of the dialog, after signing in.
+
 EOF
+
+read -r -p "$(color $Gre)Open the browser? [y/N] " response
+case "$response" in
+    [yY][eE][sS]|[yY])
+        xdg-open "https://github.com/settings/tokens/new?scopes=repo,admin:public_key,gist,read:org&description=MIL+token"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
 
 read -r -p "$(color $Gre)Enter the PAT (it should start with ghp_): " response
 echo "$response" > token.txt

--- a/scripts/store_git.sh
+++ b/scripts/store_git.sh
@@ -21,6 +21,7 @@ color() {
 # header display functions
 hash_header() { echo "########################################"; }
 
+# Display header
 clear
 cat << EOF
 $(color $Pur)
@@ -67,11 +68,17 @@ case "$response" in
         ;;
 esac
 
+###################
+# Git setup
+###################
+
+# Check whether git name and email are configured
 clear
 GitName="$(git config --global user.name)"
 GitEmail="$(git config --global user.email)"
 GitFixNeeded=0
 
+# Configure both if needed
 if [ "$GitName" != "" ]
 then
 cat << EOF

--- a/scripts/store_git.sh
+++ b/scripts/store_git.sh
@@ -1,0 +1,58 @@
+#! /bin/sh
+# Author: Cameron Brown
+
+# From https://stackoverflow.com/a/16844327 - thanks!
+RCol='\e[0m'    # Text Reset
+
+# Regular           Bold                Underline           High Intensity      BoldHigh Intens     Background          High Intensity Backgrounds
+Bla='\e[0;30m';     BBla='\e[1;30m';    UBla='\e[4;30m';    IBla='\e[0;90m';    BIBla='\e[1;90m';   On_Bla='\e[40m';    On_IBla='\e[0;100m';
+Red='\e[0;31m';     BRed='\e[1;31m';    URed='\e[4;31m';    IRed='\e[0;91m';    BIRed='\e[1;91m';   On_Red='\e[41m';    On_IRed='\e[0;101m';
+Gre='\e[0;32m';     BGre='\e[1;32m';    UGre='\e[4;32m';    IGre='\e[0;92m';    BIGre='\e[1;92m';   On_Gre='\e[42m';    On_IGre='\e[0;102m';
+Yel='\e[0;33m';     BYel='\e[1;33m';    UYel='\e[4;33m';    IYel='\e[0;93m';    BIYel='\e[1;93m';   On_Yel='\e[43m';    On_IYel='\e[0;103m';
+Blu='\e[0;34m';     BBlu='\e[1;34m';    UBlu='\e[4;34m';    IBlu='\e[0;94m';    BIBlu='\e[1;94m';   On_Blu='\e[44m';    On_IBlu='\e[0;104m';
+Pur='\e[0;35m';     BPur='\e[1;35m';    UPur='\e[4;35m';    IPur='\e[0;95m';    BIPur='\e[1;95m';   On_Pur='\e[45m';    On_IPur='\e[0;105m';
+Cya='\e[0;36m';     BCya='\e[1;36m';    UCya='\e[4;36m';    ICya='\e[0;96m';    BICya='\e[1;96m';   On_Cya='\e[46m';    On_ICya='\e[0;106m';
+Whi='\e[0;37m';     BWhi='\e[1;37m';    UWhi='\e[4;37m';    IWhi='\e[0;97m';    BIWhi='\e[1;97m';   On_Whi='\e[47m';    On_IWhi='\e[0;107m';
+
+color() {
+    printf "$1"
+}
+
+# header display functions
+hash_header() { echo "########################################"; }
+
+clear
+cat << EOF
+$(color $Pur)
+         &@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@#
+       @@@@@@*,...................................................,/@@@@@@
+     ,@@@@                                                            ,@@@@
+     (@@@(                      /////&@* (@%////*                      &@@@*
+     (@@@(                 #         %@* (@(         &                 &@@@*
+     (@@@(                @@@@       %@* (@(      ,@@@@                &@@@*
+     (@@@(               &@@@@@@%    %@* (@(    @@@@@@@#               &@@@*
+     (@@@(              %/  @@@@@@@. %@* (@( ,@@@@@@&  #,              &@@@*
+     (@@@(             *&     ,@@@@@@@@* (@@@@@@@@      @.             &@@@*
+     (@@@(             @         (@@@@@* (@@@@@,         @             &@@@*
+     (@@@(            @             @@@* (@@#            ,@            &@@@*
+     (@@@(           &               %@* (@(              /#           &@@@*
+     (@@@(          %/               %@* (@(               %,          &@@@*
+     (@@@(         *@                %@* (@(                @.         &@@@*
+     (@@@(         @                 %@* (@(                 @         &@@@*
+     (@@@(        @                  %@* (@(                 ,@        &@@@*
+     (@@@(  .@@@@@@@@            &@@@@@* (@@@@@#            @@@@@@@@   &@@@*
+     (@@@#  .%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%   &@@@*
+     .@@@@.                                                           (@@@@
+       @@@@@@%////////////////////////////////////////////////////(&@@@@@@
+         #@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@/
+$(color $Yel)
+$(hash_header)
+Hola! Let's *git* your Git setup ready to go. You will need to do this at one point or another,
+but doing it all in one place will help to ensure that your computer stores your credentials
+quickly and securely.
+
+This script will help you:
+1. Store your Git name/email if not already set
+2. Download libcrypt, a secure library for storing Git credentials
+3. Help you create a personal access token for Git authentication
+EOF

--- a/scripts/store_git.sh
+++ b/scripts/store_git.sh
@@ -145,9 +145,9 @@ fi
 # gh setup
 #####################
 
-GhInstalled=$(gh --version)
-if [ $GhInstalled != 0 ]
+if ! type "gh" > /dev/null
 then
+clear
 cat << EOF
 $(hash_header)
 $(color $Yel)We will now setup your device authentication with GitHub using the GitHub CLI.
@@ -210,8 +210,10 @@ Follow the steps below:
    $(color $Red)Do not refresh the page or the token will disappear!
 EOF
 
-read -r -p "$(color $Gre)Enter the PAT (it should start with ghp_): " GitPAT
-cat <<< GitPAT | gh auth login --with-token
+read -r -p "$(color $Gre)Enter the PAT (it should start with ghp_): " response
+echo "$response" > token.txt
+gh auth login --with-token < token.txt
+rm token.txt
 
 clear
 cat << EOF


### PR DESCRIPTION
Adds a script to setup a credential manager for Git. This script helps new (and old) members:

* Setup their name and email with `git config`
* Download and install the GitHub CLI, `gh`
* Authenticate `git` with `gh auth login` so that pushing to the repo is possible