### PR TITLE
Fixed odom estimator to not die at launch and enabled pinger to exist by default

### DIFF
--- a/SubjuGator/simulation/sub8_gazebo/worlds/a_whole_new.world
+++ b/SubjuGator/simulation/sub8_gazebo/worlds/a_whole_new.world
@@ -135,13 +135,11 @@
       </link>
     </model>
 
-    <!--
     <include>
       <name>transdec_pinger</name>
       <uri>model://pinger</uri>
       <pose>15 0 -2 0 0 0 </pose>
     </include>
-    -->
 
     <scene>
       <sky>

--- a/mil_common/gnc/odom_estimator/src/nodelet.cpp
+++ b/mil_common/gnc/odom_estimator/src/nodelet.cpp
@@ -130,8 +130,8 @@ private:
         std::cout << "mag missing" << std::endl;
         return;
       }
-      if (last_good_dvl && *last_good_dvl > msg.header.stamp - ros::Duration(1.5) &&
-          *last_good_dvl < msg.header.stamp + ros::Duration(1.5))
+      if (last_good_dvl && (*last_good_dvl).toSec() > msg.header.stamp.toSec() - 1.5 &&
+          (*last_good_dvl).toSec() < msg.header.stamp.toSec() + 1.5 )
       {
         state = init_state(msg, *last_mag, Vec<3>(start_x_ecef, start_y_ecef, start_z_ecef), Vec<3>::Zero(),
                            last_rel_pos_ecef_);

--- a/mil_common/gnc/odom_estimator/src/nodelet.cpp
+++ b/mil_common/gnc/odom_estimator/src/nodelet.cpp
@@ -131,7 +131,7 @@ private:
         return;
       }
       if (last_good_dvl && (*last_good_dvl).toSec() > msg.header.stamp.toSec() - 1.5 &&
-          (*last_good_dvl).toSec() < msg.header.stamp.toSec() + 1.5 )
+          (*last_good_dvl).toSec() < msg.header.stamp.toSec() + 1.5)
       {
         state = init_state(msg, *last_mag, Vec<3>(start_x_ecef, start_y_ecef, start_z_ecef), Vec<3>::Zero(),
                            last_rel_pos_ecef_);

--- a/mil_common/utils/mil_tools/mil_ros_tools/vector_to_marker
+++ b/mil_common/utils/mil_tools/mil_ros_tools/vector_to_marker
@@ -30,6 +30,10 @@ class VectorToMarker(object):
         marker.header = vec.header
         marker.type = 0
         marker.color = self.color
+        marker.pose.orientation.x = 0
+        marker.pose.orientation.y = 0
+        marker.pose.orientation.z = 0
+        marker.pose.orientation.w = 1
         marker.scale.x = 0.1
         marker.scale.y = 0.15
         marker.scale.z = 0.5


### PR DESCRIPTION
You can launch ```roslaunch sub8_launch gazebo.launch``` and see no red errors.