### PR TITLE
Fix python3 issue with script

### DIFF
--- a/docker/base/system_install
+++ b/docker/base/system_install
@@ -18,6 +18,8 @@ mil_system_install --no-install-recommends \
   dirmngr \
   gnupg2 \
   lsb-release \
+  python3 \
+  python3-pip \
   python2 \
   ruby \
   wget \


### PR DESCRIPTION
Currently, the Noetic script doesn't install `python3` and `python3-pip` before attempting to install `vcstool` with `pip3`. This breaks the script. This PR adds a fix to prevent this break from happening.