### PR TITLE
Add documentation and typing to keyboard control package

### DIFF
--- a/NaviGator/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
+++ b/NaviGator/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
@@ -12,6 +12,7 @@ import curses
 
 from navigator_msgs.srv import KeyboardControl
 import rospy
+from typing import Optional
 
 
 __author__ = "Anthony Olive"
@@ -54,7 +55,7 @@ class KeyboardClient:
             "Yaw Clockwise:        arrow down ",
         ]
 
-    def read_key(self):
+    def read_key(self) -> Optional[int]:
         """
         Reads the newest key from the buffer and discards all old keys that
         were not read.
@@ -75,7 +76,7 @@ class KeyboardClient:
 
         return keycode if keycode != -1 else None
 
-    def send_key(self, event):
+    def send_key(self, _: rospy.timer.TimerEvent) -> None:
         """
         Sends the key to the keyboard server and stores the returned locked
         status and generated UUID (if one was received).
@@ -95,7 +96,7 @@ class KeyboardClient:
 
         self.refresh_status_text()
 
-    def refresh_status_text(self):
+    def refresh_status_text(self) -> None:
         """
         Updates the status bar text, which consists of the UUID and the current
         locked state, and a help menu of which key is used for what.
@@ -123,13 +124,13 @@ class KeyboardClient:
                     self.screen.addstr(y, x, self.help_menu[index])
                     index += 1
 
-    def flash(self):
+    def flash(self) -> None:
         """
         Flashes the color of the screen to white for a short time.
         """
         curses.flash()
 
-    def clear(self):
+    def clear(self) -> None:
         """
         Clears all text on the screen.
         """

--- a/NaviGator/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
+++ b/NaviGator/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Keyboard Client: The keyboard client connects to the keyboard server in order
@@ -8,9 +8,6 @@ calls. Curses is used to display a basic UI in the terminal that gives the user
 useful feedback and captures key presses to be sent to the server.
 """
 
-
-from __future__ import division
-
 import curses
 
 from navigator_msgs.srv import KeyboardControl
@@ -18,10 +15,6 @@ import rospy
 
 
 __author__ = "Anthony Olive"
-__maintainer__ = "Anthony Olive"
-__email__ = "anthony@iris-systems.net"
-__copyright__ = "Copyright 2016, MIL"
-__license__ = "MIT"
 
 
 rospy.init_node("keyboard_client", anonymous=True)

--- a/NaviGator/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_server.py
+++ b/NaviGator/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_server.py
@@ -12,7 +12,7 @@ executed.
 import curses
 import uuid
 
-from navigator_msgs.srv import KeyboardControl
+from navigator_msgs.srv import KeyboardControl, KeyboardControlRequest
 from remote_control_lib import RemoteControl
 import rospy
 
@@ -67,11 +67,14 @@ class KeyboardServer:
             curses.KEY_RIGHT,
         ]
 
-    def key_recieved(self, req):
+    def key_recieved(self, req: KeyboardControlRequest):
         """
         This function handles the process of locking control of the service to
         one client. If an 'L' is received, a UUID is generated for the client
         and control of the service is locked to it.
+
+        Args:
+            req (KeyboardControlRequest): The request received from the service.
         """
 
         # If the key pressed was L, locks control of the service to the clinet's UUID
@@ -93,9 +96,12 @@ class KeyboardServer:
         else:
             return {"generated_uuid": "", "is_locked": False}
 
-    def execute_key(self, key):
+    def execute_key(self, key: int):
         """
         Executes a remote control action based on the key that was received.
+
+        Args:
+            key (int): The keycode that is received.
         """
         if key in self.key_mappings:
             self.key_mappings[key]()

--- a/NaviGator/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_server.py
+++ b/NaviGator/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Keyboard Server: The keyboard server enables a client to control NaviGator
@@ -18,16 +18,12 @@ import rospy
 
 
 __author__ = "Anthony Olive"
-__maintainer__ = "Anthony Olive"
-__email__ = "anthony@iris-systems.net"
-__copyright__ = "Copyright 2016, MIL"
-__license__ = "MIT"
 
 
 rospy.init_node("keyboard_server")
 
 
-class KeyboardServer(object):
+class KeyboardServer:
     def __init__(self):
         self.force_scale = rospy.get_param("/joystick_wrench/force_scale", 600)
         self.torque_scale = rospy.get_param("/joystick_wrench/torque_scale", 500)

--- a/NaviGator/utils/remote_control/navigator_keyboard_control/remote_control_lib/__init__.py
+++ b/NaviGator/utils/remote_control/navigator_keyboard_control/remote_control_lib/__init__.py
@@ -1,2 +1,1 @@
-#!/usr/bin/env python
-from remote_control_lib import RemoteControl
+from .remote_control_lib import RemoteControl

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -646,6 +646,45 @@ SetBool
 
         :type: str
 
+KeyboardControl
+^^^^^^^^^^^^^^^
+
+.. attributetable:: navigator_msgs.srv._KeyboardControl.KeyboardControlRequest
+
+.. class:: navigator_msgs.srv._KeyboardControl.KeyboardControlRequest
+
+    The request class for the ``navigator_msgs/KeyboardControl`` service.
+
+    .. attribute:: uuid
+
+        The UUID of the request.
+
+        :type: str
+
+    .. attribute:: keycode
+
+        The keycode of the key that was pressed.
+
+        :type: int
+
+.. attributetable:: navigator_msgs.srv._KeyboardControl.KeyboardControlResponse
+
+.. class:: navigator_msgs.srv._KeyboardControl.KeyboardControlResponse
+
+    The response class for the ``navigator_msgs/KeyboardControl`` service.
+
+    .. attribute:: generated_uuid
+
+        The generated UUID in the response class.
+
+        :type: str
+
+    .. attribute:: is_locked
+
+        Whether the keyboard interface is locked.
+
+        :type: bool
+
 Exceptions
 ----------
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -901,3 +901,11 @@ Utility Functions
 ^^^^^^^^^^^^^^^^^
 
 .. autofunction:: thread_lock
+
+Remote Control
+^^^^^^^^^^^^^^
+
+.. attributetable:: remote_control_lib.RemoteControl
+
+.. autoclass:: remote_control_lib.RemoteControl
+    :members:

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -8,3 +8,10 @@ Occupancy Grid
 
 * **Draw an occupancy grid:** ``roscd mil_tools && ./mil_tools/nodes/ogrid_draw.py``
 * **Maintains a bag file with multiple topics:** ``roscd mil_tools && ./mil_tools/nodes/online_bagger.py``
+
+Keyboard Control
+----------------
+To control the robot using the keyboard, use the ``KeyboardClient`` and ``KeyboardServer``
+classes inside of the ``navigator_keyboard_control`` package.
+
+The two nodes within the package can be run through ``rosrun``.

--- a/mil_common/mil_missions/mil_missions_core/__init__.py
+++ b/mil_common/mil_missions/mil_missions_core/__init__.py
@@ -1,6 +1,6 @@
-from base_mission import BaseMission
-from chain_with_timeout import MakeChainWithTimeout
-from wait import MakeWait
-from mission_client import MissionClient
-from exceptions import TimeoutException, SubmissionException, ParametersException, MissionException
-from mission_result import MissionResult
+from .base_mission import BaseMission
+from .chain_with_timeout import MakeChainWithTimeout
+from .wait import MakeWait
+from .mission_client import MissionClient
+from .exceptions import TimeoutException, SubmissionException, ParametersException, MissionException
+from .mission_result import MissionResult

--- a/mil_common/mil_missions/mil_missions_core/chain_with_timeout.py
+++ b/mil_common/mil_missions/mil_missions_core/chain_with_timeout.py
@@ -1,4 +1,4 @@
-from exceptions import TimeoutException, SubmissionException, ParametersException
+from .exceptions import TimeoutException, SubmissionException, ParametersException
 from twisted.internet import defer
 from twisted.python import failure
 from txros import util
@@ -84,7 +84,7 @@ def MakeChainWithTimeout(base):
                             raise SubmissionException(mission['mission'], final.getErrorMessage())
                     else:
                         self.send_feedback('{} SUCCEEDED: {}'.format(mission['mission'], final))
-                        print 'NO FAIL BRO'
+                        print('NO FAIL BRO')
                 df = self.run_submission_with_timeout(mission['mission'], mission['timeout'], mission['parameters'])
                 df.addBoth(cb)
                 yield df

--- a/mil_common/mil_missions/mil_missions_core/mission_client.py
+++ b/mil_common/mil_missions/mil_missions_core/mission_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import rospy
 from actionlib import SimpleActionClient
 from mil_missions.msg import DoMissionAction, DoMissionGoal

--- a/mil_common/mil_missions/mil_missions_core/wait.py
+++ b/mil_common/mil_missions/mil_missions_core/wait.py
@@ -1,6 +1,6 @@
 from txros import util
 from twisted.internet import defer
-from exceptions import ParametersException
+from .exceptions import ParametersException
 
 
 def MakeWait(base):

--- a/mil_common/ros_alarms/ros_alarms/__init__.py
+++ b/mil_common/ros_alarms/ros_alarms/__init__.py
@@ -1,10 +1,10 @@
-from alarms import AlarmListener, AlarmBroadcaster, HeartbeatMonitor
-from alarms import parse_json_str, Alarm
+from .alarms import AlarmListener, AlarmBroadcaster, HeartbeatMonitor
+from .alarms import parse_json_str, Alarm
 
 try:
-    from tx_alarms import TxAlarmListener, TxAlarmBroadcaster, TxHeartbeatMonitor
+    from .tx_alarms import TxAlarmListener, TxAlarmBroadcaster, TxHeartbeatMonitor
 except:
     # No txros installed
     pass
 
-from handler_template import HandlerBase
+from .handler_template import HandlerBase


### PR DESCRIPTION
The `navigator_keyboard_control` package is missing documentation and typing - this PR adds it. Closes #457.