### PR TITLE
Added new wayfinding world files

### DIFF
--- a/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewave.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewave.world
@@ -1,0 +1,224 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <!-- COORDINATE: {'constant': 0, 'environment': 1} -->
+  <world name="robotx_example_course">
+    <!-- Estimated latitude/longitude of sydneyregatta
+	 from satellite imagery -->
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.724223</latitude_deg>
+      <longitude_deg>150.679736</longitude_deg>
+      <elevation>0.0</elevation>
+      <heading_deg>0.0</heading_deg>
+    </spherical_coordinates>
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <gui fullscreen="0">
+      <camera name="user_camera">
+        <pose>-478.101746 148.200836 13.203143 0.0 0.248344 2.936862</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+      <!--<plugin name="GUITaskWidget" filename="libgui_task_widget.so"/>-->
+    </gui>
+    <include>
+      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
+      to go into the model file to change the altitutde/height!-->
+      <pose> 0 0 0.2 0 0 0 </pose>
+      <uri>model://sydney_regatta</uri>
+    </include>
+    <!-- The posts for securing the WAM-V -->
+    <include>
+      <name>post_0</name>
+      <pose>-535.916809 154.362869 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_1</name>
+      <pose>-527.48999 153.854782 0.425844 -0.1365 0  0</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_2</name>
+      <pose>-544.832825 156.671951 0.499025 -0.162625 0 0 </pose>
+      <uri>model://post</uri>
+    </include>
+    <!-- Antenna for communication with the WAM-V -->
+    <include>
+      <pose>-531.063721 147.668579 1.59471 -0.068142 0 -0.1</pose>
+      <uri>model://antenna</uri>
+    </include>
+    <!-- ground station tents -->
+    <include>
+      <name>ground_station_0</name>
+      <pose>-540.796448 146.493744 1.671421 -0.00834 0.01824 1.301726</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_1</name>
+      <pose>-537.622681 145.827896 1.681931 -0.00603 0.018667 1.301571</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_2</name>
+      <pose>-534.550537 144.910400 1.720474 -0.004994 0.020798 1.301492</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <!-- The projectile for the ball shooter -->
+    <include>
+      <name>blue_projectile</name>
+      <pose>-545 60 0.03 0 0 0</pose>
+      <uri>model://blue_projectile</uri>
+    </include>
+    <plugin filename="libwayfinding_scoring_plugin.so" name="wayfinding_scoring_plugin">
+      <vehicle>wamv</vehicle>
+      <task_name>wayfinding</task_name>
+      <min_errors_topic>/vrx/wayfinding/min_errors</min_errors_topic>
+      <mean_error_topic>/vrx/wayfinding/mean_error</mean_error_topic>
+      <waypoints_topic>/vrx/wayfinding/waypoints</waypoints_topic>
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/debug/contact</contact_debug_topic>
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
+      <!-- Goal as Latitude, Longitude, Yaw -->
+      <waypoints>
+        <waypoint>
+          <pose>-33.722026 150.674410 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722118 150.674034 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.72211 150.674163 0.5</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722096 150.674610 -3</pose>
+        </waypoint>
+      </waypoints>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
+    </plugin>
+    <model name="ocean_waves">
+      <static>true</static>
+      <plugin filename="libWavefieldModelPlugin.so" name="wavefield_plugin">
+        <static>false</static>
+        <update_rate>30</update_rate>
+        <size>1000 1000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>8.0</period>
+          <number>3</number>
+          <scale>10</scale>
+          <gain>0.2</gain>
+          <direction>-0.5 -0.5</direction>
+          <angle>0.4</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <!-- No effect for the PMS model -->
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name="ocean_waves_link">
+        <visual name="ocean_waves_visual">
+          <plugin filename="libWavefieldVisualPlugin.so" name="ocean_waves_visual_plugin">
+            <enableRtt>true</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>8.0</period>
+              <number>3</number>
+              <scale>10</scale>
+              <gain>0.2</gain>
+              <direction>-0.5 -0.5</direction>
+              <angle>0.4</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <!-- No effect for the PMS model -->
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name="ocean_waves_below_visual">
+          <pose>0 0 -0.05 0 0 0</pose>
+          <!-- Offset to prevent rendering conflict -->
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+      </link>
+    </model>
+    <!--Gazebo Plugin for simulating WAM-V dynamics-->
+    <plugin filename="libusv_gazebo_wind_plugin.so" name="wind">
+      <!-- models to be effected by the wind -->
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector> .5 .5 .33</coeff_vector>
+      </wind_obj>
+      <!-- Wind -->
+      <wind_direction>315</wind_direction>
+      <!-- in degrees -->
+      <wind_mean_velocity>4.0</wind_mean_velocity>
+      <var_wind_gain_constants>2.0</var_wind_gain_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
+      <random_seed>15</random_seed>
+      <!-- set to zero/empty to randomize -->
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>
+        
+0.3 0.3 0.3 1    
+      </ambient>
+    </scene>
+  </world>
+</sdf>

--- a/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewave_alt.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewave_alt.world
@@ -1,0 +1,224 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <!-- COORDINATE: {'constant': 0, 'environment': 1} -->
+  <world name="robotx_example_course">
+    <!-- Estimated latitude/longitude of sydneyregatta
+	 from satellite imagery -->
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.724223</latitude_deg>
+      <longitude_deg>150.679736</longitude_deg>
+      <elevation>0.0</elevation>
+      <heading_deg>0.0</heading_deg>
+    </spherical_coordinates>
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <gui fullscreen="0">
+      <camera name="user_camera">
+        <pose>-478.101746 148.200836 13.203143 0.0 0.248344 2.936862</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+      <!--<plugin name="GUITaskWidget" filename="libgui_task_widget.so"/>-->
+    </gui>
+    <include>
+      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
+      to go into the model file to change the altitutde/height!-->
+      <pose> 0 0 0.2 0 0 0 </pose>
+      <uri>model://sydney_regatta</uri>
+    </include>
+    <!-- The posts for securing the WAM-V -->
+    <include>
+      <name>post_0</name>
+      <pose>-535.916809 154.362869 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_1</name>
+      <pose>-527.48999 153.854782 0.425844 -0.1365 0  0</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_2</name>
+      <pose>-544.832825 156.671951 0.499025 -0.162625 0 0 </pose>
+      <uri>model://post</uri>
+    </include>
+    <!-- Antenna for communication with the WAM-V -->
+    <include>
+      <pose>-531.063721 147.668579 1.59471 -0.068142 0 -0.1</pose>
+      <uri>model://antenna</uri>
+    </include>
+    <!-- ground station tents -->
+    <include>
+      <name>ground_station_0</name>
+      <pose>-540.796448 146.493744 1.671421 -0.00834 0.01824 1.301726</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_1</name>
+      <pose>-537.622681 145.827896 1.681931 -0.00603 0.018667 1.301571</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_2</name>
+      <pose>-534.550537 144.910400 1.720474 -0.004994 0.020798 1.301492</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <!-- The projectile for the ball shooter -->
+    <include>
+      <name>blue_projectile</name>
+      <pose>-545 60 0.03 0 0 0</pose>
+      <uri>model://blue_projectile</uri>
+    </include>
+    <plugin filename="libwayfinding_scoring_plugin.so" name="wayfinding_scoring_plugin">
+      <vehicle>wamv</vehicle>
+      <task_name>wayfinding</task_name>
+      <min_errors_topic>/vrx/wayfinding/min_errors</min_errors_topic>
+      <mean_error_topic>/vrx/wayfinding/mean_error</mean_error_topic>
+      <waypoints_topic>/vrx/wayfinding/waypoints</waypoints_topic>
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/debug/contact</contact_debug_topic>
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
+      <!-- Goal as Latitude, Longitude, Yaw -->
+      <waypoints>
+        <waypoint>
+          <pose>-33.722026 150.674410 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722118 150.674034 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.72211 150.674163 0.5</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722096 150.674610 -3</pose>
+        </waypoint>
+      </waypoints>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
+    </plugin>
+    <model name="ocean_waves">
+      <static>true</static>
+      <plugin filename="libWavefieldModelPlugin.so" name="wavefield_plugin">
+        <static>false</static>
+        <update_rate>30</update_rate>
+        <size>1000 1000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>7.5</period>
+          <number>3</number>
+          <scale>10</scale>
+          <gain>0.8</gain>
+          <direction>0.5 0.5</direction>
+          <angle>0.6</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <!-- No effect for the PMS model -->
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name="ocean_waves_link">
+        <visual name="ocean_waves_visual">
+          <plugin filename="libWavefieldVisualPlugin.so" name="ocean_waves_visual_plugin">
+            <enableRtt>true</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>7.5</period>
+              <number>3</number>
+              <scale>10</scale>
+              <gain>0.8</gain>
+              <direction>0.5 0.5</direction>
+              <angle>0.6</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <!-- No effect for the PMS model -->
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name="ocean_waves_below_visual">
+          <pose>0 0 -0.05 0 0 0</pose>
+          <!-- Offset to prevent rendering conflict -->
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+      </link>
+    </model>
+    <!--Gazebo Plugin for simulating WAM-V dynamics-->
+    <plugin filename="libusv_gazebo_wind_plugin.so" name="wind">
+      <!-- models to be effected by the wind -->
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector> .5 .5 .33</coeff_vector>
+      </wind_obj>
+      <!-- Wind -->
+      <wind_direction>315</wind_direction>
+      <!-- in degrees -->
+      <wind_mean_velocity>4.0</wind_mean_velocity>
+      <var_wind_gain_constants>2.0</var_wind_gain_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
+      <random_seed>15</random_seed>
+      <!-- set to zero/empty to randomize -->
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>
+        
+0.3 0.3 0.3 1    
+      </ambient>
+    </scene>
+  </world>
+</sdf>

--- a/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewavewind.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewavewind.world
@@ -1,0 +1,227 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <!-- COORDINATE: {'constant': 0, 'environment': 2} -->
+  <world name="robotx_example_course">
+    <!-- Estimated latitude/longitude of sydneyregatta
+	 from satellite imagery -->
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.724223</latitude_deg>
+      <longitude_deg>150.679736</longitude_deg>
+      <elevation>0.0</elevation>
+      <heading_deg>0.0</heading_deg>
+    </spherical_coordinates>
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <gui fullscreen="0">
+      <camera name="user_camera">
+        <pose>-478.101746 148.200836 13.203143 0.0 0.248344 2.936862</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+      <!--<plugin name="GUITaskWidget" filename="libgui_task_widget.so"/>-->
+    </gui>
+    <include>
+      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
+      to go into the model file to change the altitutde/height!-->
+      <pose> 0 0 0.2 0 0 0 </pose>
+      <uri>model://sydney_regatta</uri>
+    </include>
+    <!-- The posts for securing the WAM-V -->
+    <include>
+      <name>post_0</name>
+      <pose>-535.916809 154.362869 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_1</name>
+      <pose>-527.48999 153.854782 0.425844 -0.1365 0  0</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_2</name>
+      <pose>-544.832825 156.671951 0.499025 -0.162625 0 0 </pose>
+      <uri>model://post</uri>
+    </include>
+    <!-- Antenna for communication with the WAM-V -->
+    <include>
+      <pose>-531.063721 147.668579 1.59471 -0.068142 0 -0.1</pose>
+      <uri>model://antenna</uri>
+    </include>
+    <!-- ground station tents -->
+    <include>
+      <name>ground_station_0</name>
+      <pose>-540.796448 146.493744 1.671421 -0.00834 0.01824 1.301726</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_1</name>
+      <pose>-537.622681 145.827896 1.681931 -0.00603 0.018667 1.301571</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_2</name>
+      <pose>-534.550537 144.910400 1.720474 -0.004994 0.020798 1.301492</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <!-- The projectile for the ball shooter -->
+    <include>
+      <name>blue_projectile</name>
+      <pose>-545 60 0.03 0 0 0</pose>
+      <uri>model://blue_projectile</uri>
+    </include>
+    <plugin filename="libwayfinding_scoring_plugin.so" name="wayfinding_scoring_plugin">
+      <vehicle>wamv</vehicle>
+      <task_name>wayfinding</task_name>
+      <min_errors_topic>/vrx/wayfinding/min_errors</min_errors_topic>
+      <mean_error_topic>/vrx/wayfinding/mean_error</mean_error_topic>
+      <waypoints_topic>/vrx/wayfinding/waypoints</waypoints_topic>
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/debug/contact</contact_debug_topic>
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
+      <!-- Goal as Latitude, Longitude, Yaw -->
+      <waypoints>
+        <waypoint>
+          <pose>-33.722412 150.674364 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722262 150.674210 -1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722308 150.675065 0.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722225 150.674304 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.7224908 150.674065 -2.5</pose>
+        </waypoint>
+      </waypoints>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
+    </plugin>
+    <model name="ocean_waves">
+      <static>true</static>
+      <plugin filename="libWavefieldModelPlugin.so" name="wavefield_plugin">
+        <static>false</static>
+        <update_rate>30</update_rate>
+        <size>3000 3000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>5.0</period>
+          <number>3</number>
+          <scale>8.5</scale>
+          <gain>0.8</gain>
+          <direction>-0.95 0.1</direction>
+          <angle>0.4</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <!-- No effect for the PMS model -->
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name="ocean_waves_link">
+        <visual name="ocean_waves_visual">
+          <plugin filename="libWavefieldVisualPlugin.so" name="ocean_waves_visual_plugin">
+            <enableRtt>true</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>5.0</period>
+              <number>3</number>
+              <scale>8.5</scale>
+              <gain>0.8</gain>
+              <direction>-0.95 0.1</direction>
+              <angle>0.4</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <!-- No effect for the PMS model -->
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name="ocean_waves_below_visual">
+          <pose>0 0 -0.05 0 0 0</pose>
+          <!-- Offset to prevent rendering conflict -->
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+      </link>
+    </model>
+    <!--Gazebo Plugin for simulating WAM-V dynamics-->
+    <plugin filename="libusv_gazebo_wind_plugin.so" name="wind">
+      <!-- models to be effected by the wind -->
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector> .5 .5 .33</coeff_vector>
+      </wind_obj>
+      <!-- Wind -->
+      <wind_direction>200</wind_direction>
+      <!-- in degrees -->
+      <wind_mean_velocity>8.0</wind_mean_velocity>
+      <var_wind_gain_constants>2.0</var_wind_gain_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
+      <random_seed>9</random_seed>
+      <!-- set to zero/empty to randomize -->
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>
+        
+0.3 0.3 0.3 1    
+      </ambient>
+    </scene>
+  </world>
+</sdf>

--- a/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewavewind_alt.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewavewind_alt.world
@@ -1,0 +1,227 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <!-- COORDINATE: {'constant': 0, 'environment': 2} -->
+  <world name="robotx_example_course">
+    <!-- Estimated latitude/longitude of sydneyregatta
+	 from satellite imagery -->
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.724223</latitude_deg>
+      <longitude_deg>150.679736</longitude_deg>
+      <elevation>0.0</elevation>
+      <heading_deg>0.0</heading_deg>
+    </spherical_coordinates>
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <gui fullscreen="0">
+      <camera name="user_camera">
+        <pose>-478.101746 148.200836 13.203143 0.0 0.248344 2.936862</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+      <!--<plugin name="GUITaskWidget" filename="libgui_task_widget.so"/>-->
+    </gui>
+    <include>
+      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
+      to go into the model file to change the altitutde/height!-->
+      <pose> 0 0 0.2 0 0 0 </pose>
+      <uri>model://sydney_regatta</uri>
+    </include>
+    <!-- The posts for securing the WAM-V -->
+    <include>
+      <name>post_0</name>
+      <pose>-535.916809 154.362869 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_1</name>
+      <pose>-527.48999 153.854782 0.425844 -0.1365 0  0</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_2</name>
+      <pose>-544.832825 156.671951 0.499025 -0.162625 0 0 </pose>
+      <uri>model://post</uri>
+    </include>
+    <!-- Antenna for communication with the WAM-V -->
+    <include>
+      <pose>-531.063721 147.668579 1.59471 -0.068142 0 -0.1</pose>
+      <uri>model://antenna</uri>
+    </include>
+    <!-- ground station tents -->
+    <include>
+      <name>ground_station_0</name>
+      <pose>-540.796448 146.493744 1.671421 -0.00834 0.01824 1.301726</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_1</name>
+      <pose>-537.622681 145.827896 1.681931 -0.00603 0.018667 1.301571</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_2</name>
+      <pose>-534.550537 144.910400 1.720474 -0.004994 0.020798 1.301492</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <!-- The projectile for the ball shooter -->
+    <include>
+      <name>blue_projectile</name>
+      <pose>-545 60 0.03 0 0 0</pose>
+      <uri>model://blue_projectile</uri>
+    </include>
+    <plugin filename="libwayfinding_scoring_plugin.so" name="wayfinding_scoring_plugin">
+      <vehicle>wamv</vehicle>
+      <task_name>wayfinding</task_name>
+      <min_errors_topic>/vrx/wayfinding/min_errors</min_errors_topic>
+      <mean_error_topic>/vrx/wayfinding/mean_error</mean_error_topic>
+      <waypoints_topic>/vrx/wayfinding/waypoints</waypoints_topic>
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/debug/contact</contact_debug_topic>
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
+      <!-- Goal as Latitude, Longitude, Yaw -->
+      <waypoints>
+        <waypoint>
+          <pose>-33.722412 150.674364 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722262 150.674210 -1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722308 150.675065 0.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722225 150.674304 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.7224908 150.674065 -2.5</pose>
+        </waypoint>
+      </waypoints>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
+    </plugin>
+    <model name="ocean_waves">
+      <static>true</static>
+      <plugin filename="libWavefieldModelPlugin.so" name="wavefield_plugin">
+        <static>false</static>
+        <update_rate>30</update_rate>
+        <size>3000 3000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>6.0</period>
+          <number>3</number>
+          <scale>2.5</scale>
+          <gain>0.8</gain>
+          <direction>-0.9 0.1</direction>
+          <angle>0.8</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <!-- No effect for the PMS model -->
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name="ocean_waves_link">
+        <visual name="ocean_waves_visual">
+          <plugin filename="libWavefieldVisualPlugin.so" name="ocean_waves_visual_plugin">
+            <enableRtt>true</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>6.0</period>
+              <number>3</number>
+              <scale>2.5</scale>
+              <gain>0.8</gain>
+              <direction>-0.9 0.1</direction>
+              <angle>0.8</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <!-- No effect for the PMS model -->
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name="ocean_waves_below_visual">
+          <pose>0 0 -0.05 0 0 0</pose>
+          <!-- Offset to prevent rendering conflict -->
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+      </link>
+    </model>
+    <!--Gazebo Plugin for simulating WAM-V dynamics-->
+    <plugin filename="libusv_gazebo_wind_plugin.so" name="wind">
+      <!-- models to be effected by the wind -->
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector> .5 .5 .33</coeff_vector>
+      </wind_obj>
+      <!-- Wind -->
+      <wind_direction>200</wind_direction>
+      <!-- in degrees -->
+      <wind_mean_velocity>7.8</wind_mean_velocity>
+      <var_wind_gain_constants>7.0</var_wind_gain_constants>
+      <var_wind_time_constants>10</var_wind_time_constants>
+      <random_seed>9</random_seed>
+      <!-- set to zero/empty to randomize -->
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>
+        
+0.3 0.3 0.3 1    
+      </ambient>
+    </scene>
+  </world>
+</sdf>

--- a/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewind.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewind.world
@@ -1,0 +1,224 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <!-- COORDINATE: {'constant': 0, 'environment': 1} -->
+  <world name="robotx_example_course">
+    <!-- Estimated latitude/longitude of sydneyregatta
+	 from satellite imagery -->
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.724223</latitude_deg>
+      <longitude_deg>150.679736</longitude_deg>
+      <elevation>0.0</elevation>
+      <heading_deg>0.0</heading_deg>
+    </spherical_coordinates>
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <gui fullscreen="0">
+      <camera name="user_camera">
+        <pose>-478.101746 148.200836 13.203143 0.0 0.248344 2.936862</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+      <!--<plugin name="GUITaskWidget" filename="libgui_task_widget.so"/>-->
+    </gui>
+    <include>
+      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
+      to go into the model file to change the altitutde/height!-->
+      <pose> 0 0 0.2 0 0 0 </pose>
+      <uri>model://sydney_regatta</uri>
+    </include>
+    <!-- The posts for securing the WAM-V -->
+    <include>
+      <name>post_0</name>
+      <pose>-535.916809 154.362869 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_1</name>
+      <pose>-527.48999 153.854782 0.425844 -0.1365 0  0</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_2</name>
+      <pose>-544.832825 156.671951 0.499025 -0.162625 0 0 </pose>
+      <uri>model://post</uri>
+    </include>
+    <!-- Antenna for communication with the WAM-V -->
+    <include>
+      <pose>-531.063721 147.668579 1.59471 -0.068142 0 -0.1</pose>
+      <uri>model://antenna</uri>
+    </include>
+    <!-- ground station tents -->
+    <include>
+      <name>ground_station_0</name>
+      <pose>-540.796448 146.493744 1.671421 -0.00834 0.01824 1.301726</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_1</name>
+      <pose>-537.622681 145.827896 1.681931 -0.00603 0.018667 1.301571</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_2</name>
+      <pose>-534.550537 144.910400 1.720474 -0.004994 0.020798 1.301492</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <!-- The projectile for the ball shooter -->
+    <include>
+      <name>blue_projectile</name>
+      <pose>-545 60 0.03 0 0 0</pose>
+      <uri>model://blue_projectile</uri>
+    </include>
+    <plugin filename="libwayfinding_scoring_plugin.so" name="wayfinding_scoring_plugin">
+      <vehicle>wamv</vehicle>
+      <task_name>wayfinding</task_name>
+      <min_errors_topic>/vrx/wayfinding/min_errors</min_errors_topic>
+      <mean_error_topic>/vrx/wayfinding/mean_error</mean_error_topic>
+      <waypoints_topic>/vrx/wayfinding/waypoints</waypoints_topic>
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/debug/contact</contact_debug_topic>
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
+      <!-- Goal as Latitude, Longitude, Yaw -->
+      <waypoints>
+	<waypoint>
+          <pose>-33.722036 150.674310 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722128 150.674434 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.72212 150.674163 0.5</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722196 150.674510 -3</pose>
+        </waypoint>
+      </waypoints>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
+    </plugin>
+    <model name="ocean_waves">
+      <static>true</static>
+      <plugin filename="libWavefieldModelPlugin.so" name="wavefield_plugin">
+        <static>false</static>
+        <update_rate>30</update_rate>
+        <size>1000 1000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>8.0</period>
+          <number>3</number>
+          <scale>2.5</scale>
+          <gain>0.2</gain>
+          <direction>0.5 0.5</direction>
+          <angle>0.4</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <!-- No effect for the PMS model -->
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name="ocean_waves_link">
+        <visual name="ocean_waves_visual">
+          <plugin filename="libWavefieldVisualPlugin.so" name="ocean_waves_visual_plugin">
+            <enableRtt>true</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>8.0</period>
+              <number>3</number>
+              <scale>2.5</scale>
+              <gain>0.2</gain>
+              <direction>0.5 0.5</direction>
+              <angle>0.4</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <!-- No effect for the PMS model -->
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name="ocean_waves_below_visual">
+          <pose>0 0 -0.05 0 0 0</pose>
+          <!-- Offset to prevent rendering conflict -->
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+      </link>
+    </model>
+    <!--Gazebo Plugin for simulating WAM-V dynamics-->
+    <plugin filename="libusv_gazebo_wind_plugin.so" name="wind">
+      <!-- models to be effected by the wind -->
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector> .5 -.5 .33</coeff_vector>
+      </wind_obj>
+      <!-- Wind -->
+      <wind_direction>310</wind_direction>
+      <!-- in degrees -->
+      <wind_mean_velocity>10.0</wind_mean_velocity>
+      <var_wind_gain_constants>2.5</var_wind_gain_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
+      <random_seed>15</random_seed>
+      <!-- set to zero/empty to randomize -->
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>
+        
+0.3 0.3 0.3 1    
+      </ambient>
+    </scene>
+  </world>
+</sdf>

--- a/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewind_alt.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/wayfinding_largewind_alt.world
@@ -1,0 +1,224 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <!-- COORDINATE: {'constant': 0, 'environment': 1} -->
+  <world name="robotx_example_course">
+    <!-- Estimated latitude/longitude of sydneyregatta
+	 from satellite imagery -->
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.724223</latitude_deg>
+      <longitude_deg>150.679736</longitude_deg>
+      <elevation>0.0</elevation>
+      <heading_deg>0.0</heading_deg>
+    </spherical_coordinates>
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <gui fullscreen="0">
+      <camera name="user_camera">
+        <pose>-478.101746 148.200836 13.203143 0.0 0.248344 2.936862</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+      <!--<plugin name="GUITaskWidget" filename="libgui_task_widget.so"/>-->
+    </gui>
+    <include>
+      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
+      to go into the model file to change the altitutde/height!-->
+      <pose> 0 0 0.2 0 0 0 </pose>
+      <uri>model://sydney_regatta</uri>
+    </include>
+    <!-- The posts for securing the WAM-V -->
+    <include>
+      <name>post_0</name>
+      <pose>-535.916809 154.362869 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_1</name>
+      <pose>-527.48999 153.854782 0.425844 -0.1365 0  0</pose>
+      <uri>model://post</uri>
+    </include>
+    <include>
+      <name>post_2</name>
+      <pose>-544.832825 156.671951 0.499025 -0.162625 0 0 </pose>
+      <uri>model://post</uri>
+    </include>
+    <!-- Antenna for communication with the WAM-V -->
+    <include>
+      <pose>-531.063721 147.668579 1.59471 -0.068142 0 -0.1</pose>
+      <uri>model://antenna</uri>
+    </include>
+    <!-- ground station tents -->
+    <include>
+      <name>ground_station_0</name>
+      <pose>-540.796448 146.493744 1.671421 -0.00834 0.01824 1.301726</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_1</name>
+      <pose>-537.622681 145.827896 1.681931 -0.00603 0.018667 1.301571</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <include>
+      <name>ground_station_2</name>
+      <pose>-534.550537 144.910400 1.720474 -0.004994 0.020798 1.301492</pose>
+      <uri>model://ground_station</uri>
+    </include>
+    <!-- The projectile for the ball shooter -->
+    <include>
+      <name>blue_projectile</name>
+      <pose>-545 60 0.03 0 0 0</pose>
+      <uri>model://blue_projectile</uri>
+    </include>
+    <plugin filename="libwayfinding_scoring_plugin.so" name="wayfinding_scoring_plugin">
+      <vehicle>wamv</vehicle>
+      <task_name>wayfinding</task_name>
+      <min_errors_topic>/vrx/wayfinding/min_errors</min_errors_topic>
+      <mean_error_topic>/vrx/wayfinding/mean_error</mean_error_topic>
+      <waypoints_topic>/vrx/wayfinding/waypoints</waypoints_topic>
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/debug/contact</contact_debug_topic>
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
+      <!-- Goal as Latitude, Longitude, Yaw -->
+      <waypoints>
+	<waypoint>
+          <pose>-33.722036 150.674310 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722128 150.674434 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.72212 150.674163 0.5</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722196 150.674510 -3</pose>
+        </waypoint>
+      </waypoints>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
+    </plugin>
+    <model name="ocean_waves">
+      <static>true</static>
+      <plugin filename="libWavefieldModelPlugin.so" name="wavefield_plugin">
+        <static>false</static>
+        <update_rate>30</update_rate>
+        <size>1000 1000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>8.0</period>
+          <number>3</number>
+          <scale>2.5</scale>
+          <gain>0.2</gain>
+          <direction>0.5 0.5</direction>
+          <angle>0.4</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <!-- No effect for the PMS model -->
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name="ocean_waves_link">
+        <visual name="ocean_waves_visual">
+          <plugin filename="libWavefieldVisualPlugin.so" name="ocean_waves_visual_plugin">
+            <enableRtt>true</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>8.0</period>
+              <number>3</number>
+              <scale>2.5</scale>
+              <gain>0.2</gain>
+              <direction>0.5 0.5</direction>
+              <angle>0.4</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <!-- No effect for the PMS model -->
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name="ocean_waves_below_visual">
+          <pose>0 0 -0.05 0 0 0</pose>
+          <!-- Offset to prevent rendering conflict -->
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+      </link>
+    </model>
+    <!--Gazebo Plugin for simulating WAM-V dynamics-->
+    <plugin filename="libusv_gazebo_wind_plugin.so" name="wind">
+      <!-- models to be effected by the wind -->
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector> .5 -.5 .33</coeff_vector>
+      </wind_obj>
+      <!-- Wind -->
+      <wind_direction>180</wind_direction>
+      <!-- in degrees -->
+      <wind_mean_velocity>8.0</wind_mean_velocity>
+      <var_wind_gain_constants>5</var_wind_gain_constants>
+      <var_wind_time_constants>3</var_wind_time_constants>
+      <random_seed>15</random_seed>
+      <!-- set to zero/empty to randomize -->
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>
+        
+0.3 0.3 0.3 1    
+      </ambient>
+    </scene>
+  </world>
+</sdf>


### PR DESCRIPTION
**Commit 1**
Added new wayfinding task worlds that are harder:

-wayfinding_largewave.world (only the wave parameters and waypoints are changed)
-wayfinding_largewind.world (only the wind parameters and waypoints are changed)
-wayfinding_largewavewind.world (the wind, wave, and waypoints are changed)

Each of the new worlds have new waypoint locations, different from the other new world files. The direction of the waves and wind are also changed in some new world files as well. 

**Commit 2**
Added three new wayfinding worlds with names "alt". These worlds match up better with the parameters specified in vrx2022 technical guide. I kept the other worlds as well in case we want to use them for additional testing. Some parameters do not fall within the ones vrx will give, but the values are pretty close.

This fixes #471