### PR TITLE
Migrate `ros_alarms` from Python 2 to Python 3 and add documentation

### DIFF
--- a/ci/build_docs
+++ b/ci/build_docs
@@ -15,5 +15,5 @@ doxygen $MIL_DIR/docs/Doxyfile
 cd -
 
 # Then Sphinx build
-sphinx-build -E -b html -d $BUILD_DIR/doctrees  "-W" $MIL_DIR $BUILD_DIR/html
+sphinx-build -E -b html -d $BUILD_DIR/doctrees $MIL_DIR $BUILD_DIR/html
 echo "Docs available at file://$BUILD_DIR/html/index.html"

--- a/conf.py
+++ b/conf.py
@@ -63,6 +63,9 @@ breathe_default_project = 'mil'
 breathe_implementation_filename_extensions = ['.c', '.cc', '.cpp']
 breathe_default_members = ('members', 'undoc-members')
 
+# Document __init__ methods of classes
+autoclass_content = "both"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['docs/_templates']
 

--- a/conf.py
+++ b/conf.py
@@ -25,6 +25,11 @@ from sphinx.ext import graphviz
 sys.path.insert(0, os.path.abspath('..'))
 sys.path.append(os.path.abspath('docs/extensions'))
 
+# Node extensions
+sys.path.append(os.path.abspath('mil_common'))
+sys.path.append(os.path.abspath('mil_common/ros_alarms'))
+sys.path.append(os.path.abspath('mil_common/ros_alarms/nodes'))
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -764,7 +764,7 @@ AlarmGet
 
         The response data about the requested alarm.
 
-        :type: Alarm
+        :type: ~ros_alarms.msg._Alarm.Alarm
 
 AlarmSet
 ^^^^^^^^
@@ -779,7 +779,7 @@ AlarmSet
 
         The alarm to set.
 
-        :type: Alarm
+        :type: ~ros_alarms.msg._Alarm.Alarm
 
 .. attributetable:: ros_alarms.srv._AlarmSet.AlarmSetResponse
 
@@ -1060,29 +1060,45 @@ Remote Control
 Alarms
 ------
 
-AlarmProxy
-^^^^^^^^^^
-.. doxygenstruct:: ros_alarms::AlarmProxy
+Python
+^^^^^^
 
-AlarmBroadcaster
-^^^^^^^^^^^^^^^^
-.. doxygenclass:: ros_alarms::AlarmBroadcaster
+Alarm
+~~~~~
+.. currentmodule:: ros_alarms
 
-AlarmListener
-^^^^^^^^^^^^^
-.. doxygenclass:: ros_alarms::AlarmListener
+.. attributetable:: ros_alarms.Alarm
 
-ListenerCb
-^^^^^^^^^^
-.. doxygenstruct:: ros_alarms::ListenerCb
-
-HeartbeatMonitor
-^^^^^^^^^^^^^^^^
-.. doxygenclass:: ros_alarms::HeartbeatMonitor
+.. autoclass:: ros_alarms.Alarm
+    :members:
 
 AlarmServer
-^^^^^^^^^^^
+~~~~~~~~~~~
 .. currentmodule:: mil_common.ros_alarms
 
 .. autoclass:: ros_alarms.nodes.alarm_server.AlarmServer
     :members:
+   
+C++
+^^^
+
+AlarmProxy
+~~~~~~~~~~
+.. doxygenstruct:: ros_alarms::AlarmProxy
+
+AlarmBroadcaster
+~~~~~~~~~~~~~~~~
+.. doxygenclass:: ros_alarms::AlarmBroadcaster
+
+AlarmListener
+~~~~~~~~~~~~~
+.. doxygenclass:: ros_alarms::AlarmListener
+
+ListenerCb
+~~~~~~~~~~
+.. doxygenstruct:: ros_alarms::ListenerCb
+
+HeartbeatMonitor
+~~~~~~~~~~~~~~~~
+.. doxygenclass:: ros_alarms::HeartbeatMonitor
+

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1107,6 +1107,16 @@ HeartbeatMonitor
 
 .. autoclass:: ros_alarms.HeartbeatMonitor
     :members:
+
+HandlerBase
+~~~~~~~~~~~
+.. currentmodule:: ros_alarms
+
+.. attributetable:: ros_alarms.HandlerBase
+
+.. autoclass:: ros_alarms.HandlerBase
+    :members:
+
    
 C++
 ^^^

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1076,7 +1076,36 @@ AlarmServer
 ~~~~~~~~~~~
 .. currentmodule:: mil_common.ros_alarms
 
+.. attributetable:: ros_alarms.nodes.alarm_server.AlarmServer
+
 .. autoclass:: ros_alarms.nodes.alarm_server.AlarmServer
+    :members:
+
+AlarmBroadcaster
+~~~~~~~~~~~~~~~~
+.. currentmodule:: ros_alarms
+
+.. attributetable:: ros_alarms.AlarmBroadcaster
+
+.. autoclass:: ros_alarms.AlarmBroadcaster
+    :members:
+
+AlarmListener
+~~~~~~~~~~~~~
+.. currentmodule:: ros_alarms
+
+.. attributetable:: ros_alarms.AlarmListener
+
+.. autoclass:: ros_alarms.AlarmListener
+    :members:
+
+HeartbeatMonitor
+~~~~~~~~~~~~~~~~
+.. currentmodule:: ros_alarms
+
+.. attributetable:: ros_alarms.HeartbeatMonitor
+
+.. autoclass:: ros_alarms.HeartbeatMonitor
     :members:
    
 C++

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1015,3 +1015,7 @@ AlarmListener
 ListenerCb
 ^^^^^^^^^^
 .. doxygenstruct:: ros_alarms::ListenerCb
+
+HeartbeatMonitor
+^^^^^^^^^^^^^^^^
+.. doxygenclass:: ros_alarms::HeartbeatMonitor

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -40,6 +40,54 @@ GoalStatus
         A constant of the message type used to indicate a goal which succeeded. 
         Truly set to 2.
 
+Alarms
+^^^^^^
+
+Alarm
+~~~~~
+
+.. attributetable:: ros_alarms.msg._Alarm.Alarm
+
+.. class:: ros_alarms.msg._Alarm.Alarm
+
+    A message representing a ROS Alarm.
+
+    .. attribute:: alarm_name
+
+        The name of the alarm.
+
+        :type: str
+
+    .. attribute:: raised
+
+        Whether the alarm was raised.
+
+        :type: bool
+
+    .. attribute:: node_name
+
+        The node name associated with the alarm.
+
+        :type: str
+
+    .. attribute:: problem_description
+
+        The problem description associated with the alarm.
+
+        :type: str
+
+    .. attribute:: parameters
+
+        The JSON parameters associated with the alarm.
+
+        :type: str
+
+    .. attribute:: severity
+
+        The severity of the alarm.
+
+        :type: int
+
 Geometry Messages
 ^^^^^^^^^^^^^^^^^
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -733,6 +733,66 @@ KeyboardControl
 
         :type: bool
 
+AlarmGet
+^^^^^^^^
+
+.. attributetable:: ros_alarms.srv._AlarmGet.AlarmGetRequest
+
+.. class:: ros_alarms.srv._AlarmGet.AlarmGetRequest
+
+   The request class for the ``ros_alarms/AlarmGet`` service.
+
+   .. attribute:: alarm_name
+
+        The name of the alarm to request data about.
+
+        :type: str
+
+.. attributetable:: ros_alarms.srv._AlarmGet.AlarmGetResponse
+
+.. class:: ros_alarms.srv._AlarmGet.AlarmGetResponse
+
+   The repsonse class for the ``ros_alarms/AlarmGet`` service.
+
+   .. attribute:: header
+
+        The header for the response.
+
+        :type: Header
+
+   .. attribute:: alarm
+
+        The response data about the requested alarm.
+
+        :type: Alarm
+
+AlarmSet
+^^^^^^^^
+
+.. attributetable:: ros_alarms.srv._AlarmSet.AlarmSetRequest
+
+.. class:: ros_alarms.srv._AlarmSet.AlarmSetRequest
+
+   The request class for the ``ros_alarms/AlarmSet`` service.
+
+   .. attribute:: alarm
+
+        The alarm to set.
+
+        :type: Alarm
+
+.. attributetable:: ros_alarms.srv._AlarmSet.AlarmSetResponse
+
+.. class:: ros_alarms.srv._AlarmSet.AlarmSetResponse
+
+   The repsonse class for the ``ros_alarms/AlarmSet`` service.
+
+   .. attribute:: succeed
+
+        Whether the request succeeded.
+
+        :type: bool
+
 Exceptions
 ----------
 
@@ -1019,3 +1079,10 @@ ListenerCb
 HeartbeatMonitor
 ^^^^^^^^^^^^^^^^
 .. doxygenclass:: ros_alarms::HeartbeatMonitor
+
+AlarmServer
+^^^^^^^^^^^
+.. currentmodule:: mil_common.ros_alarms
+
+.. autoclass:: ros_alarms.nodes.alarm_server.AlarmServer
+    :members:

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -15,3 +15,10 @@ To control the robot using the keyboard, use the ``KeyboardClient`` and ``Keyboa
 classes inside of the ``navigator_keyboard_control`` package.
 
 The two nodes within the package can be run through ``rosrun``.
+
+Alarms
+------
+* **Clear an alarm:** ``roscd ros_alarms && rosrun nodes/clear.py``
+* **Monitor an alarm:** ``roscd ros_alarms && rosrun nodes/monitor.py``
+* **Raise an alarm:** ``roscd ros_alarms && rosrun nodes/raise.py``
+* **Reports the status of an alarm:** ``roscd ros_alarms && rosrun nodes/report.py``

--- a/mil_common/ros_alarms/include/ros_alarms/alarm_proxy.hpp
+++ b/mil_common/ros_alarms/include/ros_alarms/alarm_proxy.hpp
@@ -12,6 +12,10 @@
 
 namespace ros_alarms
 {
+/**
+ * Representation of a ROS alarm. Used by several other classes to faciliate proper
+ * interactions between components.
+ */
 struct AlarmProxy
 {
   /**

--- a/mil_common/ros_alarms/include/ros_alarms/alarm_proxy.hpp
+++ b/mil_common/ros_alarms/include/ros_alarms/alarm_proxy.hpp
@@ -14,30 +14,85 @@ namespace ros_alarms
 {
 struct AlarmProxy
 {
+  /**
+   * The default class constructor. All parameters are empty or zero.
+   */
   AlarmProxy()
   {
-  }  // Default ctor (cleared, severity = 0, empty strings
+  }
 
+  /**
+   * A constructor which has parameters for all class parameters.
+   */
   AlarmProxy(std::string alarm_name,  // full ctor
              bool raised, std::string node_name, std::string problem_description, std::string json_parameters,
              int severity);
 
+  /**
+   * A constructor with parameters for all class attributes, except the node name,
+   * which is dervied from the current node name (using ``ros::this_node``).
+   */
   AlarmProxy(std::string alarm_name,  // ctor without node name
              bool raised, std::string problem_description, std::string json_parameters, int severity);
 
-  AlarmProxy(ros_alarms::Alarm msg);  // ctor from ros msg
+  /**
+   * Constructs the class from a ROS message.
+   *
+   * @param msg The message to construct the class from.
+   */
+  AlarmProxy(ros_alarms::Alarm msg);
 
+  /**
+   * Converts the Alarm Proxy object to an :class:`Alarm` message.
+   *
+   * @return The constructed message.
+   */
   Alarm as_msg();  // convert to ros msg
 
+  /**
+   * Prints a readable representation of the class. Normally prints the alarm name,
+   * alarm status, and whether the alarm is raised or cleared. If raised, the severity
+   * is also printed.
+   *
+   * The full representation also prints the node name, a problem description,
+   * and any related JSON parameters.
+   *
+   * @param full Whether to print the full description.
+   */
   std::string str(bool full = false) const;  // Returns printable representaion of AlarmProxy
 
+  /**
+   * Overloaded equality operator. Returns true if both alarms share the same name,
+   * raised status, node name, problem description, and status.
+   *
+   * @param other The other alarm.
+   */
   bool operator==(const AlarmProxy &other) const;
 
   // Public fields
+  /**
+   * The alarm name.
+   */
   std::string alarm_name;
+
+  /**
+   * Whether the alarm has been raised by some service.
+   */
   bool raised = false;
+
+  /**
+   * The name of the node connected to the alarm.
+   */
   std::string node_name;
+
+  /**
+   * The description of the problem associated with the alarm.
+   */
   std::string problem_description;
+
+  /**
+   * The JSON parameters associated with the alarm.
+   */
   std::string json_parameters;
   int severity = 0;
 };

--- a/mil_common/ros_alarms/include/ros_alarms/broadcaster.hpp
+++ b/mil_common/ros_alarms/include/ros_alarms/broadcaster.hpp
@@ -10,6 +10,9 @@
 
 namespace ros_alarms
 {
+/**
+ * Facilitates operations on an alarm, such as raising or clearing an alarm.
+ */
 class AlarmBroadcaster
 {
 public:

--- a/mil_common/ros_alarms/include/ros_alarms/broadcaster.hpp
+++ b/mil_common/ros_alarms/include/ros_alarms/broadcaster.hpp
@@ -15,22 +15,38 @@ class AlarmBroadcaster
 public:
   // Constuct a broadcaster w/ an internally controlled (default) or externally controlled
   // (optional ptr argument) AlarmProxy
+  /**
+   * Constructs a broadcaster with an internally controlled (default) or externally controlled AlarmProxy.
+   *
+   * @param nh The node handle to associate with the broadcaster.
+   * @param alarm The alarm proxy.
+   */
   AlarmBroadcaster(ros::NodeHandle& nh, AlarmProxy* alarm = nullptr);
 
-  // Change alarm status and publish to server
+  /**
+   * Clears the alarm, and publishes the change to the server.
+   */
   void clear()
   {
     __alarm_ptr->raised = false;
     publish();
   }
+
+  /**
+   * Raises the alarm, and publishes the change to the server.
+   */
   void raise()
   {
     __alarm_ptr->raised = true;
     publish();
   }
 
-  // updateSeverity always raises the alarm because it doesn't make sense for
-  // cleared alarm to have severity
+  /**
+   * Updates the severity associated with an alarm, and raises the alarm. This
+   * function should not be used to update the alarm severity to zero.
+   *
+   * @param sev The new severity.
+   */
   void updateSeverity(int sev)
   {
     __alarm_ptr->severity = sev;
@@ -38,12 +54,21 @@ public:
   }
 
   /** 
-   * Publishes current state of the AlarmProxy to the server
+   * Publishes current state of the AlarmProxy to the server. If the publication encountered an error, a ROS warning is sent alongside returning ``false``.
+   *
+   * @return The success of the publication.
    */
   bool publish();
 
   // Handle to update the AlarmProxy (if this is an externally managed AlPxy, then modifying
   // could potentially have side effects for other broadcasters that may use it. Exert Caution!)
+  /**
+   * Returns the alarm proxy associated with the broadcaster.
+   *
+   * Warning: If the class uses an externally modified alarm proxy, then modifying this class could have reprocussions for other services which rely on that alarm proxy.
+   *
+   * @return The proxy.
+   */
   AlarmProxy& getAlarm()
   {
     return *__alarm_ptr;

--- a/mil_common/ros_alarms/include/ros_alarms/listener.hpp
+++ b/mil_common/ros_alarms/include/ros_alarms/listener.hpp
@@ -118,28 +118,59 @@ public:
     return __last_alarm;
   }
 
-  // Registers a callback to be invoked on both raise and clear
+  /**
+   * Registers a callback to be invoked on both raise and clear.
+   *
+   * @param cb The callback function.
+   */
   void addCb(callable_t cb);
 
-  // Registers a raise callback to be called for any severity level
+  /**
+   * Registers a callback to be invoked for any severity level.
+   *
+   * @param cb The callback function.
+   */
   void addRaiseCb(callable_t cb);
 
-  // Registers a raise callback to be called for a single severity level
+  /**
+   * Registers a callback to be invoked for a single severity level.
+   *
+   * @param cb The callback function.
+   * @param severity The severity level to execute the callback for.
+   */
   void addRaiseCb(callable_t cb, int severity);
 
-  // Registers a callback to be invoked at alarm raise for a range of severities
+  /**
+   * Registers a callback to be invoked for a range of severity levels.
+   *
+   * @param cb The callback function.
+   * @param severity_lo The lowest severity level to execute the callback for.
+   * @param severity_hi The highest severity level to execute the callback for.
+   */
   void addRaiseCb(callable_t cb, int severity_lo, int severity_hi);
 
-  // Registers a callback to be invoked when alarm is cleared
+  /**
+   * Registers a callback to be invoked when an alarm is cleared.
+   *
+   * @param cb The callback function.
+   */
   void addClearCb(callable_t cb);
 
-  // Returns the last time the alarm was updated
+  /**
+   * Returns the last time the alarm was updated.
+   *
+   * @return The most recent update time.
+   */
   ros::Time getLastUpdateTime() const
   {
     return __last_update;
   }
 
-  // Returns the time since last update
+  /**
+   * Returns the amount of time since the alarm was updated.
+   *
+   * @return The length of time since the alarm was updated.
+   */
   ros::Duration getTimeSinceUpdate() const
   {
     return ros::Time::now() - __last_update;
@@ -148,6 +179,9 @@ public:
   // Waits for an update to the alarm via '/alarm/udates' with timeout
   bool waitForUpdate(ros::Duration timeout = ros::Duration(-1.0)) const;
 
+  /**
+   * Clears all callback associated with the listener.
+   */
   void clearCallbacks()
   {
     __callbacks.clear();
@@ -214,6 +248,13 @@ catch (std::exception &e)
   ROS_ERROR("%s", msg.str().c_str());
 }
 
+/**
+ * Waits for a connection to connect to the subscriber as a publisher.
+ *
+ * @param timeout The amount of time before the function returns ``false``.
+ *
+ * @return Whether a connection has been established.
+ */
 template <typename callable_t>
 bool AlarmListener<callable_t>::waitForConnection(ros::Duration timeout)
 {

--- a/mil_common/ros_alarms/nodes/alarm_server.py
+++ b/mil_common/ros_alarms/nodes/alarm_server.py
@@ -3,7 +3,13 @@ import rospy
 from ros_alarms import HandlerBase
 
 from ros_alarms.msg import Alarm as AlarmMsg
-from ros_alarms.srv import AlarmGet, AlarmSet, AlarmSetRequest, AlarmGetRequest, AlarmGetResponse
+from ros_alarms.srv import (
+    AlarmGet,
+    AlarmSet,
+    AlarmSetRequest,
+    AlarmGetRequest,
+    AlarmGetResponse,
+)
 from ros_alarms import Alarm
 
 import inspect
@@ -21,6 +27,7 @@ class AlarmServer:
         meta_alarms (Dict[str, ros_alarms.Alarm]): A map from the meta alarm names to the Alarm
             objects.
     """
+
     def __init__(self):
         # Maps alarm name to Alarm objects
         self.alarms = {}
@@ -46,7 +53,7 @@ class AlarmServer:
 
     def set_alarm(self, alarm: Union[Alarm, AlarmMsg]) -> bool:
         """
-        Sets or updates the alarm. 
+        Sets or updates the alarm.
 
         Updating the alarm triggers all of the alarms callbacks, if any are set.
         The alarm becomes registered within the server and a message representing
@@ -90,7 +97,7 @@ class AlarmServer:
 
     def make_tagged_alarm(self, name: str) -> Alarm:
         """
-        Makes a blank alarm with the node_name of the alarm_server so that users 
+        Makes a blank alarm with the node_name of the alarm_server so that users
         know it is the initial state.
         """
         alarm = Alarm.blank(name)
@@ -201,7 +208,7 @@ class AlarmServer:
         """
 
         meta_alarms_dict = rospy.get_param(namespace, {})
-        for meta, alarms in meta_alarms_dict.iteritems():
+        for meta, alarms in meta_alarms_dict.items():
             # Add the meta alarm
             if meta not in self.alarms:
                 self.alarms[meta] = self.make_tagged_alarm(meta)

--- a/mil_common/ros_alarms/ros_alarms/alarms.py
+++ b/mil_common/ros_alarms/ros_alarms/alarms.py
@@ -97,8 +97,9 @@ class Alarm:
             when the alarm is cleared. Each callback should be associated with
             the severity required to execute the callback through a tuple.
     """
+
     @classmethod
-    def blank(cls, name: str) -> 'Alarm':
+    def blank(cls, name: str) -> "Alarm":
         """
         Generate a general blank alarm that is cleared with a low severity.
 
@@ -111,7 +112,7 @@ class Alarm:
         return cls(name, raised=False, severity=0)
 
     @classmethod
-    def from_msg(cls, msg: AlarmMsg) -> 'Alarm':
+    def from_msg(cls, msg: AlarmMsg) -> "Alarm":
         """
         Generate an alarm object from an Alarm message.
 
@@ -219,9 +220,9 @@ class Alarm:
                         )
                     )
 
-    def update(self, srv: 'Alarm'):
+    def update(self, srv: "Alarm"):
         """
-        Updates this alarm with a new AlarmSet request. Also will call any 
+        Updates this alarm with a new AlarmSet request. Also will call any
         required callbacks.
 
         Args:
@@ -293,7 +294,10 @@ class AlarmBroadcaster:
     Broadcasts information about an alarm, and allows for the raising and clearing
     of the alarm.
     """
-    def __init__(self, name: str, node_name: Optional[str] = None, nowarn: bool = False):
+
+    def __init__(
+        self, name: str, node_name: Optional[str] = None, nowarn: bool = False
+    ):
         """
         Args:
             name (str): The name of the related alarm.
@@ -310,10 +314,10 @@ class AlarmBroadcaster:
 
     def wait_for_server(self, timeout=None):
         """
-        Wait for node to connect to alarm server. Waits timeout seconds (or forever 
-            if ``timeout`` is ``None``) to connect then fetches the current alarm 
+        Wait for node to connect to alarm server. Waits timeout seconds (or forever
+            if ``timeout`` is ``None``) to connect then fetches the current alarm
             and calls callbacks as needed.
-        
+
         .. warning::
 
             User should always call this method before calling other methods.
@@ -357,13 +361,13 @@ class AlarmBroadcaster:
             kwargs: The associated keyword arguments, as described below.
 
         Keyword Arguments:
-            node_name (str): String that holds the name of the node making the 
+            node_name (str): String that holds the name of the node making the
                 request.
-            problem_description (str): String with a description of the problem 
+            problem_description (str): String with a description of the problem
                 (defaults to empty string).
-            parameters (dict): JSON dumpable dictionary with optional parameters 
+            parameters (dict): JSON dumpable dictionary with optional parameters
                 that describe the alarm.
-            severity (int): Integer in [0, 5] that indicates the severity of 
+            severity (int): Integer in [0, 5] that indicates the severity of
                 the alarm. (5 is most severe)
 
         Returns:
@@ -383,13 +387,13 @@ class AlarmBroadcaster:
             kwargs: The associated keyword arguments, as described below.
 
         Keyword Arguments:
-            node_name (str): String that holds the name of the node making the 
+            node_name (str): String that holds the name of the node making the
                 request.
-            problem_description (str): String with a description of the problem 
+            problem_description (str): String with a description of the problem
                 (defaults to empty string).
-            parameters (dict): JSON dumpable dictionary with optional parameters 
+            parameters (dict): JSON dumpable dictionary with optional parameters
                 that describe the alarm.
-            severity (int): Integer in [0, 5] that indicates the severity of 
+            severity (int): Integer in [0, 5] that indicates the severity of
                 the alarm. (5 is most severe)
 
         Returns:
@@ -406,7 +410,14 @@ class AlarmListener:
     """
     Listens to an alarm.
     """
-    def __init__(self, name: str, callback_funct: Optional[Callable] = None, nowarn: bool = False, **kwargs):
+
+    def __init__(
+        self,
+        name: str,
+        callback_funct: Optional[Callable] = None,
+        nowarn: bool = False,
+        **kwargs
+    ):
         """
         Args:
             name (str): The alarm name.
@@ -430,10 +441,10 @@ class AlarmListener:
 
     def wait_for_server(self, timeout: Optional[float] = None):
         """
-        Wait for node to connect to alarm server. Waits timeout seconds (or forever 
-            if ``timeout`` is ``None``) to connect then fetches the current alarm 
+        Wait for node to connect to alarm server. Waits timeout seconds (or forever
+            if ``timeout`` is ``None``) to connect then fetches the current alarm
             and calls callbacks as needed.
-        
+
         .. warning::
 
             User should always call this method before calling other methods.
@@ -473,7 +484,7 @@ class AlarmListener:
     def is_cleared(self, fetch: bool = True) -> bool:
         """
         Returns whether this alarm is cleared or not.
-        
+
         Args:
             fetch (bool): Whether to fetch the alarm from the server. If ``False``,
                 then uses the most recently cached alarm. Defaults to ``True``.
@@ -609,6 +620,7 @@ class HeartbeatMonitor(AlarmBroadcaster):
 
     All of this class' methods and attribues are internal.
     """
+
     def __init__(
         self,
         alarm_name: str,

--- a/mil_common/ros_alarms/ros_alarms/handler_template.py
+++ b/mil_common/ros_alarms/ros_alarms/handler_template.py
@@ -1,88 +1,105 @@
-class HandlerBase:
+from .alarms import Alarm
+from ros_alarms.msg import Alarm as AlarmMsg
 
+from typing import Union, Optional
+
+class HandlerBase:
     """
-    Listens for an alarm with this `alarm_name`.
-    When that alarm is raised, self.raised will be called.
-    When that alarm is cleared, self.cleared will be called.
-    See the comments below for self.meta_predicate.
+    Listens for an alarm with this `alarm_name`. When that alarm is raised, 
+    self.raised will be called. When that alarm is cleared, self.cleared will 
+    be called. See the comments below for self.meta_predicate.
 
     All alarm handlers must inherit from this base class in order to be registered.
     """
-
     alarm_name = "generic-name"
     severity_required = (0, 5)
     alarm_server = None
 
     @classmethod
-    def _init(cls, alarm_server):
+    def _init(cls, alarm_server: 'AlarmServer'):
         """
         Called by the alarm server to give each handler a reference to the alarm server,
-        so it can efficiently get and set alarms
+        so it can efficiently get and set alarms.
+
+        Args:
+            alarm_server (AlarmServer): An existing AlarmServer instance.
         """
         cls._alarm_server = alarm_server
 
     @property
-    def current_alarm(self):
+    def current_alarm(self) -> Optional[Alarm]:
         """
-        Returns the status of the alarm this handler is registered for
+        Returns the status of the alarm this handler is registered for.
+
+        Returns:
+            Optional[Alarm]: The current alarm instance, if it exists, otherwise ``None``.
         """
         return self.get_alarm(self.alarm_name)
 
-    def get_alarm(self, name):
+    def get_alarm(self, name: str) -> Optional[Alarm]:
         """
-        Gets the current status of an alarm
-        @return The request alarm object, or None if it has not been set
+        Gets the current status of an alarm.
+
+        Returns:
+            Optional[Alarm]: The request alarm object, or None if it has not been set.
         """
         return self._alarm_server.alarms.get(name)
 
-    def on_set(self, new_alarm):
+    def on_set(self, new_alarm: AlarmMsg) -> Optional[bool]:
         """
         Called whenever a service request is made to the alarm server to the
         alarm this handler is registered for. Can be used to trigger actions
         before other nodes are notified of the change or to reject the change.
         By default, defers to the raised and cleared functions below.
-        @param new_alarm: Alarm message that is requested to change to
-        @return Either None, in which case the change is accepted or False,
-                in which case the alarm remains the same and the service request fails.
+
+        Args:
+            new_alarm (ros_alarms.msg._Alarm.Alarm): Alarm message that is 
+                requested to have this alarm change to.
+
+        Returns:
+            Optional[bool]: Either ``None``, in which case the change is accepted or ``False``,
+            in which case the alarm remains the same and the service request fails.
         """
         if new_alarm.raised:
             return self.raised(new_alarm)
         else:
             return self.cleared(new_alarm)
-        return
 
-    def raised(self, alarm):
+    def raised(self, alarm: AlarmMsg):
         """
         Unless on_set is overriden, called whenever a node requests this alarm be raised.
-        If it returns False, this request is denied. Otherwise, the alarm is raised
-        @param alarm: the new alarm a node had requested to replace the current with
+        If it returns False, this request is denied. Otherwise, the alarm is raised.
+
+        Args:
+            alarm (ros_alarms.msg._Alarm.Alarm): The new alarm a node had requested to replace the 
+                current with.
         """
         return
 
-    def cleared(self, alarm):
+    def cleared(self, alarm: AlarmMsg):
         """
         Unless on_set is overriden, called whenever a node requests this alarm be cleared.
         If it returns False, this request is denied. Otherwise, the alarm is raised
-        @param alarm: the new alarm a node had requested to replace the current with
+
+        Args:
+            alarm (ros_alarms.msg._Alarm.Alarm): The new alarm a node had requested to replace the 
+                current with.
         """
         return
 
-    def meta_predicate(self, meta_alarm, alarms):
+    def meta_predicate(self, meta_alarm: Alarm, alarms) -> Union[bool, Alarm]:
         """
         Called on an update to one of this alarms's meta alarms, if there are any.
-
-        @param meta_alarm: The alarm object of the meta alarm which was just changed, triggering this callback
-        @param alarms: a dictionary with the alarms objects for EVERY meta alarm for this alarm.
-                       ex: {'odom-kill' : Alarm('odom-kill', False),
-                            'network-loss': Alarm('network-loss', True, 'heartbeat stopped'}
-
-        MUST return either a boolean indiciating if this alarm should now be raised,
-             OR an Alarm object which will be the new status of this alarm
-
-        If a boolean is returned, this alarms status will be updated if it differs from the current raised status.
-
-        If an alarm object is returned, this alarm will be updated unconditionaly to the returned object.
-
         By default, returns True if any meta alarms are raised.
+
+        Args:
+            meta_alarm (ros_alarms.Alarm): The alarm object of the meta alarm.
+            alarms (Dict[str, ros_alarms.Alarm]): A dictionary mapping the name
+                of each child alarm to its Alarm object.
+
+        Returns:
+            Union[bool, ros_alarms.Alarm]: Returns a bool indicating if the alarm
+            should be raised, or a new Alarm object which the calling alarm
+            should update itself to.
         """
         return any([alarm.raised for name, alarm in alarms.items()])

--- a/mil_common/ros_alarms/ros_alarms/handler_template.py
+++ b/mil_common/ros_alarms/ros_alarms/handler_template.py
@@ -3,20 +3,22 @@ from ros_alarms.msg import Alarm as AlarmMsg
 
 from typing import Union, Optional
 
+
 class HandlerBase:
     """
-    Listens for an alarm with this `alarm_name`. When that alarm is raised, 
-    self.raised will be called. When that alarm is cleared, self.cleared will 
+    Listens for an alarm with this `alarm_name`. When that alarm is raised,
+    self.raised will be called. When that alarm is cleared, self.cleared will
     be called. See the comments below for self.meta_predicate.
 
     All alarm handlers must inherit from this base class in order to be registered.
     """
+
     alarm_name = "generic-name"
     severity_required = (0, 5)
     alarm_server = None
 
     @classmethod
-    def _init(cls, alarm_server: 'AlarmServer'):
+    def _init(cls, alarm_server: "AlarmServer"):
         """
         Called by the alarm server to give each handler a reference to the alarm server,
         so it can efficiently get and set alarms.
@@ -53,7 +55,7 @@ class HandlerBase:
         By default, defers to the raised and cleared functions below.
 
         Args:
-            new_alarm (ros_alarms.msg._Alarm.Alarm): Alarm message that is 
+            new_alarm (ros_alarms.msg._Alarm.Alarm): Alarm message that is
                 requested to have this alarm change to.
 
         Returns:
@@ -71,7 +73,7 @@ class HandlerBase:
         If it returns False, this request is denied. Otherwise, the alarm is raised.
 
         Args:
-            alarm (ros_alarms.msg._Alarm.Alarm): The new alarm a node had requested to replace the 
+            alarm (ros_alarms.msg._Alarm.Alarm): The new alarm a node had requested to replace the
                 current with.
         """
         return
@@ -82,7 +84,7 @@ class HandlerBase:
         If it returns False, this request is denied. Otherwise, the alarm is raised
 
         Args:
-            alarm (ros_alarms.msg._Alarm.Alarm): The new alarm a node had requested to replace the 
+            alarm (ros_alarms.msg._Alarm.Alarm): The new alarm a node had requested to replace the
                 current with.
         """
         return


### PR DESCRIPTION
This migrates the `ros_alarms` package from Python 2 to Python 3 and adds documentation to the doc site.