### PR TITLE
Convert battery monitor to py3 and document

### DIFF
--- a/NaviGator/utils/navigator_battery_monitor/nodes/navigator_battery_monitor.py
+++ b/NaviGator/utils/navigator_battery_monitor/nodes/navigator_battery_monitor.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-'''
+"""
 Battery Monitor: A simple script that approximates the battery voltage by
 averaging the supply voltage to each of the four thrusters.
-'''
+"""
 
 
 from __future__ import division
@@ -13,6 +13,7 @@ import rospy
 from std_msgs.msg import Float32
 import message_filters
 from ros_alarms import AlarmListener
+from ros_alarms.msg import Alarm
 
 
 __author__ = "Anthony Olive"
@@ -22,16 +23,21 @@ __copyright__ = "Copyright 2016, MIL"
 __license__ = "MIT"
 
 
-rospy.init_node("battery_monitor")
-
-
-class BatteryMonitor():
-    '''
+class BatteryMonitor:
+    """
     Monitors the battery voltage measured by the 4 motors on Navigator,
     publishing a moving average of these measurements to /battery_monitor
-    at a regular interval
-    '''
+    at a regular interval.
 
+    Attributes:
+        voltage (Optional[float]): The average voltage across all of the four motors.
+            ``None`` if no reading has occurred yet.
+        supply_voltages (List[float]): The most recent 1000 voltage readings.
+            Each reading is from a separate motor.
+        hw_kill_raised (bool): Whether a hardware kill was raised.
+        pub_voltage (rospy.Publisher): A publisher to the ``/battery_monitor``
+            topic. Published by the :meth:`.publish_voltage` method.
+    """
     def __init__(self):
 
         # Initialize the average voltage to none for the case of no feedback
@@ -42,57 +48,77 @@ class BatteryMonitor():
         self.supply_voltages = []
 
         self.hw_kill_raised = None
-        self._hw_kill_listener = AlarmListener('hw-kill', self.hw_kill_cb)
+        self._hw_kill_listener = AlarmListener("hw-kill", self.hw_kill_cb)
         self._hw_kill_listener.wait_for_server()
 
         # The publisher for the averaged voltage
-        self.pub_voltage = rospy.Publisher(
-            "/battery_monitor", Float32, queue_size=1)
+        self.pub_voltage = rospy.Publisher("/battery_monitor", Float32, queue_size=1)
 
         # Subscribes to the feedback from each of the four thrusters
-        motor_topics = ['/FL_motor', '/FR_motor', '/BL_motor', '/BR_motor']
+        motor_topics = ["/FL_motor", "/FR_motor", "/BL_motor", "/BR_motor"]
 
-        feedback_sub = [message_filters.Subscriber(
-            topic + '/feedback', Feedback) for topic in motor_topics]
+        feedback_sub = [
+            message_filters.Subscriber(topic + "/feedback", Feedback)
+            for topic in motor_topics
+        ]
 
-        status_sub = [message_filters.Subscriber(
-            topic + '/status', Status) for topic in motor_topics]
+        status_sub = [
+            message_filters.Subscriber(topic + "/status", Status)
+            for topic in motor_topics
+        ]
 
-        [message_filters.ApproximateTimeSynchronizer([feedback, status], 1, 10).registerCallback(
-            self.add_voltage) for feedback, status in zip(feedback_sub, status_sub)]
+        [
+            message_filters.ApproximateTimeSynchronizer(
+                [feedback, status], 1, 10
+            ).registerCallback(self.add_voltage)
+            for feedback, status in zip(feedback_sub, status_sub)
+        ]
 
-    def hw_kill_cb(self, msg):
+    def hw_kill_cb(self, msg: Alarm):
+        """
+        Serves as a callback when a hardware kill is activated.
+
+        Args:
+            msg (~ros_alarms.msg._Alarm.Alarm): The alarm message that activated
+                the hardware kill.
+        """
         self.hw_kill_raised = msg.raised
 
-    def add_voltage(self, feedback, status):
-        '''
+    def add_voltage(self, feedback: Feedback, status: Status) -> None:
+        """
         This is the callback function for feedback from all four motors.
+
         It appends the new readings to the end of the list and
         ensures that the list stays under 1000 entries.
-        '''
 
+        Args:
+            feedback (~roboteq_msgs.msg._Feedback.Feedback): The feedback from
+                one of the motors.
+            status (~roboteq_msgs.msg._Status.Status): The status of the motor.
+        """
         # Check if 3rd bit is raised
         if status.fault & 4 == 4 or self.hw_kill_raised is True:
             return
         self.supply_voltages.append(feedback.supply_voltage)
 
         # Limits the list by removing the oldest readings when it contains more then 1000 readings
-        while (len(self.supply_voltages) > 1000):
+        while len(self.supply_voltages) > 1000:
             del self.supply_voltages[0]
 
-    def publish_voltage(self, event):
-        '''
-        Publishes the average voltage across all four thrusters to the battery_voltage node
-        as a standard Float32 message and runs the voltage_check
-        '''
+    def publish_voltage(self, _) -> None:
+        """
+        Publishes the average voltage across all four thrusters to the ``battery_voltage`` node
+        as a standard Float32 message and runs the voltage_check.
 
-        if (len(self.supply_voltages) > 0):
-            self.voltage = sum(self.supply_voltages) / \
-                len(self.supply_voltages)
+        Currently runs every second.
+        """
+        if len(self.supply_voltages) > 0:
+            self.voltage = sum(self.supply_voltages) / len(self.supply_voltages)
             self.pub_voltage.publish(self.voltage)
 
 
 if __name__ == "__main__":
+    rospy.init_node("battery_monitor")
     monitor = BatteryMonitor()
     rospy.Timer(rospy.Duration(1), monitor.publish_voltage, oneshot=False)
     rospy.spin()

--- a/conf.py
+++ b/conf.py
@@ -35,6 +35,10 @@ sys.path.append(os.path.abspath('NaviGator/gnc'))
 sys.path.append(os.path.abspath('NaviGator/gnc/navigator_path_planner'))
 sys.path.append(os.path.abspath('NaviGator/gnc/navigator_path_planner/nodes'))
 
+sys.path.append(os.path.abspath('NaviGator/utils'))
+sys.path.append(os.path.abspath('NaviGator/utils/navigator_battery_monitor'))
+sys.path.append(os.path.abspath('NaviGator/utils/navigator_battery_monitor/nodes'))
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -993,6 +993,236 @@ PointCloud2
 
         :type: bool
 
+Motor Feedback
+^^^^^^^^^^^^^^
+.. attributetable:: roboteq_msgs.msg._Feedback.Feedback
+
+.. class:: roboteq_msgs.msg._Feedback.Feedback
+
+    A third-party ROS message type for getting feedback from motor controllers.
+
+    .. attribute:: header
+
+        The header of the message.
+
+        :type: Header
+
+    .. attribute:: motor_current
+
+        Current flowing through the motors.
+
+        :type: float
+
+    .. attribute:: motor_power
+
+        Relative motor power, as a proportion of the full motor power.
+        Lives in a range from -1 to 1.
+
+        :type: float
+
+    .. attribute:: commanded_velocity
+
+        The velocity commanded of the motor. Output is in ``rad/s``.
+
+        :type: float
+
+    .. attribute:: measured_velocity
+
+        The true velocity of the motor. Output is in ``rad/s``.
+
+        :type: float
+
+    .. attribute:: measured_position
+
+        The position of the motor, in ``rad``. Wraps around -6/6M.
+
+        :type: float
+
+    .. attribute:: supply_voltage
+
+        The voltage supplied to the motor, in volts.
+
+        :type: float
+
+    .. attribute:: supply_current
+
+        The current supplied to the motor, in amps.
+
+        :type: float
+
+    .. attribute:: motor_temperature
+
+        The temperature of the motor, in Celsius.
+
+        :type: float
+
+    .. attribute:: channel_temperature
+
+        The temperature of the FETs, as reported by the controller. Units are in
+        Celsius.
+
+        :type: float
+
+Motor Status
+^^^^^^^^^^^^^^
+.. attributetable:: roboteq_msgs.msg._Status.Status
+
+.. class:: roboteq_msgs.msg._Status.Status
+
+    A third-party ROS message type for getting status from motor controllers.
+
+    .. attribute:: header
+
+        The header of the message.
+
+        :type: Header
+
+    .. attribute:: fault
+
+        A representation of any fault that occurred in the motor. Likely one of the
+        enumerated fault types of this class.
+ 
+        :type: int
+
+    .. attribute:: FAULT_OVERHEAT
+
+        Constant attribute used to represent that the motor experienced a fault
+        as a result of overheating.
+
+        :type: int
+        :value: 1
+
+    .. attribute:: FAULT_OVERVOLTAGE
+
+        Constant attribute used to represent that the motor experienced a fault
+        as a result of too much voltage.
+
+        :type: int
+        :value: 2
+
+    .. attribute:: FAULT_UNDERVOLTAGE
+
+        Constant attribute used to represent that the motor experienced a fault
+        as a result of too little voltage.
+
+        :type: int
+        :value: 4
+
+    .. attribute:: FAULT_SHORT_CIRCUIT
+
+        Constant attribute used to represent that the motor experienced a fault
+        as a result of a short circuit.
+
+        :type: int
+        :value: 8
+
+    .. attribute:: FAULT_EMERGENCY_STOP
+
+        Constant attribute used to represent that the motor experienced a fault
+        as a result of an emergency stop.
+
+        :type: int
+        :value: 16
+
+    .. attribute:: FAULT_SEPEX_EXCITATION_FAULT
+
+        Constant attribute used to represent that the motor experienced a fault
+        as a result of an excitation error.
+
+        :type: int
+        :value: 32
+
+    .. attribute:: FAULT_MOSFET_FAILURE
+
+        Constant attribute used to represent that the motor experienced a fault
+        as a result of a failure in the MOSFET system.
+
+        :type: int
+        :value: 64
+
+    .. attribute:: FAULT_STARTUP_CONFIG_FAULT
+
+        Constant attribute used to represent that the motor experienced a fault
+        as a result of a failure in the startup configuration.
+
+        :type: int
+        :value: 128
+
+    .. attribute:: status
+
+        The status of the motor. Likely set to a combination of the class' enumerated
+        types.
+
+        :type: int
+
+    .. attribute:: STATUS_SERIAL_MODE
+
+        Constant attribute used to represent that the motor is in serial mode.
+
+        :type: int
+        :value: 1
+
+    .. attribute:: STATUS_PULSE_MODE
+
+        Constant attribute used to represent that the motor is in pulse mode.
+
+        :type: int
+        :value: 2
+
+    .. attribute:: STATUS_ANALOG_MODE
+
+        Constant attribute used to represent that the motor is in analog mode.
+
+        :type: int
+        :value: 4
+
+    .. attribute:: STATUS_POWER_STAGE_OFF
+
+        Constant attribute used to represent that the power stage of the motor is
+        off.
+
+        :type: int
+        :value: 8
+
+    .. attribute:: STATUS_STALL_DETECTED
+
+        Constant attribute used to represent that a stall was detected.
+
+        :type: int
+        :value: 16
+
+    .. attribute:: STATUS_AT_LIMIT
+
+        Constant attribute used to represent that the motor is at its limit.
+
+        :type: int
+        :value: 32
+
+    .. attribute:: STATUS_MICROBASIC_SCRIPT_RUNNING
+
+        Constant attribute used to represent that the microbasic script is running.
+
+        :type: int
+        :value: 128
+
+    .. attribute:: ic_temperature
+
+        The temperature of the main logic chip, in Celsius.
+
+        :type: float
+
+    .. attribute:: internal_voltage
+
+        The internal voltage, in volts.
+
+        :type: float
+
+    .. attribute:: adc_voltage
+
+        The voltage of the analog-to-digital converter, in volts.
+
+        :type: float
+
 VRX Messages
 ^^^^^^^^^^^^
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3102,3 +3102,13 @@ Node
 
 .. autoclass:: navigator_path_planner.nodes.path_planner.LQRRT_Node
     :members:
+
+Battery Monitor
+^^^^^^^^^^^^^^^
+
+.. currentmodule:: navigator_battery_monitor
+
+.. attributetable:: nodes.navigator_battery_monitor.BatteryMonitor
+
+.. autoclass:: nodes.navigator_battery_monitor.BatteryMonitor
+    :members:

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -994,7 +994,7 @@ PointCloud2
         :type: bool
 
 Motor Feedback
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~
 .. attributetable:: roboteq_msgs.msg._Feedback.Feedback
 
 .. class:: roboteq_msgs.msg._Feedback.Feedback
@@ -1064,7 +1064,7 @@ Motor Feedback
         :type: float
 
 Motor Status
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~
 .. attributetable:: roboteq_msgs.msg._Status.Status
 
 .. class:: roboteq_msgs.msg._Status.Status
@@ -3334,7 +3334,7 @@ Node
     :members:
 
 Battery Monitor
-^^^^^^^^^^^^^^^
+---------------
 
 .. currentmodule:: navigator_battery_monitor
 


### PR DESCRIPTION
This adds documentation and py3 capability for the Navigator battery monitor.