### PR TITLE
flag -D added to build_docs script to build docs with Doxygen enabled

### DIFF
--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -42,7 +42,7 @@ jobs:
             image: example/docker-ros-test:latest
             options: -v ${{ github.workspace }}/docker/noetic/html_output:/root/.mil/docs/html
             run: |
-              ./scripts/build_docs
+              ./scripts/build_docs -D
 
       - uses: actions/upload-artifact@v2
         with:

--- a/ci/build_docs
+++ b/ci/build_docs
@@ -1,37 +1,20 @@
 #!/bin/bash
 
-if [ $# -eq 0 ]; then
-    set -euo pipefail
+# Get root directory of MIL repo
+MIL_DIR="$(realpath $(dirname $BASH_SOURCE)/..)"
 
-    # Get root directory of MIL repo
-    MIL_DIR="$(realpath $(dirname $BASH_SOURCE)/..)"
+# Directory to build docs into
+BUILD_DIR=$HOME/.mil/docs
+mkdir -p $BUILD_DIR/doctrees
+mkdir -p $BUILD_DIR/html
 
-    # Directory to build docs into
-    BUILD_DIR=$HOME/.mil/docs
-    mkdir -p $BUILD_DIR/doctrees
-    mkdir -p $BUILD_DIR/html
-
-    # Then Sphinx build
-    sphinx-build -E -b html -d $BUILD_DIR/doctrees $MIL_DIR $BUILD_DIR/html
-    echo "Docs available at file://$BUILD_DIR/html/index.html"
-    exit 1
-elif [ "$1" == "-D" ]; then 
-    set -euo pipefail
-
-    # Get root directory of MIL repo
-    MIL_DIR="$(realpath $(dirname $BASH_SOURCE)/..)"
-
-    # Directory to build docs into
-    BUILD_DIR=$HOME/.mil/docs
-    mkdir -p $BUILD_DIR/doctrees
-    mkdir -p $BUILD_DIR/html
-
+if [ "$1" == "-D" ]; then 
     #Doxygen
     cd $HOME/.mil
     doxygen $MIL_DIR/docs/Doxyfile
     cd -
-
-    # Then Sphinx build
-    sphinx-build -E -b html -d $BUILD_DIR/doctrees $MIL_DIR $BUILD_DIR/html
-    echo "Docs available at file://$BUILD_DIR/html/index.html"
 fi
+
+# Then Sphinx build
+sphinx-build -E -b html -d $BUILD_DIR/doctrees $MIL_DIR $BUILD_DIR/html
+echo "Docs available at file://$BUILD_DIR/html/index.html"

--- a/ci/build_docs
+++ b/ci/build_docs
@@ -1,19 +1,37 @@
 #!/bin/bash
-set -euo pipefail
 
-# Get root directory of MIL repo
-MIL_DIR="$(realpath $(dirname $BASH_SOURCE)/..)"
+if [ $# -eq 0 ]; then
+    set -euo pipefail
 
-# Directory to build docs into
-BUILD_DIR=$HOME/.mil/docs
-mkdir -p $BUILD_DIR/doctrees
-mkdir -p $BUILD_DIR/html
+    # Get root directory of MIL repo
+    MIL_DIR="$(realpath $(dirname $BASH_SOURCE)/..)"
 
-# First run doxygen
-cd $HOME/.mil
-doxygen $MIL_DIR/docs/Doxyfile
-cd -
+    # Directory to build docs into
+    BUILD_DIR=$HOME/.mil/docs
+    mkdir -p $BUILD_DIR/doctrees
+    mkdir -p $BUILD_DIR/html
 
-# Then Sphinx build
-sphinx-build -E -b html -d $BUILD_DIR/doctrees $MIL_DIR $BUILD_DIR/html
-echo "Docs available at file://$BUILD_DIR/html/index.html"
+    # Then Sphinx build
+    sphinx-build -E -b html -d $BUILD_DIR/doctrees $MIL_DIR $BUILD_DIR/html
+    echo "Docs available at file://$BUILD_DIR/html/index.html"
+    exit 1
+elif [ "$1" == "-D" ]; then 
+    set -euo pipefail
+
+    # Get root directory of MIL repo
+    MIL_DIR="$(realpath $(dirname $BASH_SOURCE)/..)"
+
+    # Directory to build docs into
+    BUILD_DIR=$HOME/.mil/docs
+    mkdir -p $BUILD_DIR/doctrees
+    mkdir -p $BUILD_DIR/html
+
+    #Doxygen
+    cd $HOME/.mil
+    doxygen $MIL_DIR/docs/Doxyfile
+    cd -
+
+    # Then Sphinx build
+    sphinx-build -E -b html -d $BUILD_DIR/doctrees $MIL_DIR $BUILD_DIR/html
+    echo "Docs available at file://$BUILD_DIR/html/index.html"
+fi

--- a/docker/base/system_install
+++ b/docker/base/system_install
@@ -41,6 +41,7 @@ sudo add-apt-repository universe
 sudo apt update
 curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
 python2 get-pip.py
+rm get-pip.py
 
 # ROS apt source
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
@@ -79,7 +80,7 @@ mil_system_install \
   ros-noetic-ros-controllers \
 
 # Install recent pip packages being used
-sudo pip3 install --upgrade pip \
+sudo pip3 install --ignore-installed --upgrade pip \
     tsp_solver2 \
     Pillow \
     black \


### PR DESCRIPTION
added a flag -D to the script "./scripts/build_docs" to enable rebuilding the C++ docs with Doxygen

running "./scripts/build_docs" without -D rebuilds the C++ docs without Doxygen