### PR TITLE
Document the `mil_usb_to_can` package

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -63,7 +63,8 @@ intersphinx_mapping = {
   'py': ('https://docs.python.org/3', None),
   'aio': ('https://docs.aiohttp.org/en/stable/', None),
   'req': ('https://docs.python-requests.org/en/latest/', None),
-  'numpy': ('https://numpy.org/doc/stable/', None)
+  'numpy': ('https://numpy.org/doc/stable/', None),
+  'serial': ('https://pyserial.readthedocs.io/en/latest/', None)
 }
 
 breathe_projects = {'mil': os.path.expanduser('~/.mil/doxygen/xml')}

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3135,6 +3135,13 @@ Exceptons
 
         :rtype: :class:`str`
 
+.. currentmodule:: mil_usb_to_can
+
+.. attributetable:: ApplicationPacketWrongIdentifierException
+
+.. autoclass:: ApplicationPacketWrongIdentifierException
+    :members:
+
 Mathematics 
 -------------------
 
@@ -3647,3 +3654,20 @@ SylphaseSonarToRosNode
 .. cppattributetable:: SylphaseSonarToRosNode
 
 .. doxygenclass:: SylphaseSonarToRosNode
+
+CAN Communication
+-----------------
+
+ApplicationPacket
+^^^^^^^^^^^^^^^^^
+.. attributetable:: mil_usb_to_can.ApplicationPacket
+
+.. autoclass:: mil_usb_to_can.ApplicationPacket
+    :members:
+
+USBtoCANBoard
+^^^^^^^^^^^^^
+.. attributetable:: mil_usb_to_can.USBtoCANBoard
+
+.. autoclass:: mil_usb_to_can.USBtoCANBoard
+    :members:

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3137,9 +3137,25 @@ Exceptons
 
 .. currentmodule:: mil_usb_to_can
 
-.. attributetable:: ApplicationPacketWrongIdentifierException
-
 .. autoclass:: ApplicationPacketWrongIdentifierException
+    :members:
+
+.. autoclass:: USB2CANException
+    :members:
+
+.. autoclass:: ChecksumException
+    :members:
+
+.. autoclass:: PayloadTooLargeException
+    :members:
+
+.. autoclass:: InvalidFlagException
+    :members:
+
+.. autoclass:: InvalidStartFlagException
+    :members:
+
+.. autoclass:: InvalidEndFlagException
     :members:
 
 Mathematics 
@@ -3684,4 +3700,39 @@ USBtoCANDriver
 .. attributetable:: mil_usb_to_can.USBtoCANDriver
 
 .. autoclass:: mil_usb_to_can.USBtoCANDriver
+    :members:
+
+SimulatedCANDevice
+^^^^^^^^^^^^^^^^^^
+.. attributetable:: mil_usb_to_can.SimulatedCANDevice
+
+.. autoclass:: mil_usb_to_can.SimulatedCANDevice
+    :members:
+
+SimulatedUSBtoCAN
+^^^^^^^^^^^^^^^^^
+.. attributetable:: mil_usb_to_can.SimulatedUSBtoCAN
+
+.. autoclass:: mil_usb_to_can.SimulatedUSBtoCAN
+    :members:
+
+Packet
+^^^^^^
+.. attributetable:: mil_usb_to_can.Packet
+
+.. autoclass:: mil_usb_to_can.Packet
+    :members:
+
+ReceivePacket
+^^^^^^^^^^^^^
+.. attributetable:: mil_usb_to_can.ReceivePacket
+
+.. autoclass:: mil_usb_to_can.ReceivePacket
+    :members:
+
+CommandPacket
+^^^^^^^^^^^^^
+.. attributetable:: mil_usb_to_can.CommandPacket
+
+.. autoclass:: mil_usb_to_can.CommandPacket
     :members:

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3671,3 +3671,17 @@ USBtoCANBoard
 
 .. autoclass:: mil_usb_to_can.USBtoCANBoard
     :members:
+
+CANDeviceHandle
+^^^^^^^^^^^^^^^
+.. attributetable:: mil_usb_to_can.CANDeviceHandle
+
+.. autoclass:: mil_usb_to_can.CANDeviceHandle
+    :members:
+
+USBtoCANDriver
+^^^^^^^^^^^^^^
+.. attributetable:: mil_usb_to_can.USBtoCANDriver
+
+.. autoclass:: mil_usb_to_can.USBtoCANDriver
+    :members:

--- a/mil_common/drivers/mil_usb_to_can/mil_usb_to_can/__init__.py
+++ b/mil_common/drivers/mil_usb_to_can/mil_usb_to_can/__init__.py
@@ -11,3 +11,4 @@ from .simulation import (
 )
 from .device import CANDeviceHandle, ExampleEchoDeviceHandle, ExampleAdderDeviceHandle
 from .board import USBtoCANBoard
+from .driver import USBtoCANDriver

--- a/mil_common/drivers/mil_usb_to_can/mil_usb_to_can/__init__.py
+++ b/mil_common/drivers/mil_usb_to_can/mil_usb_to_can/__init__.py
@@ -1,5 +1,15 @@
 #!/usr/bin/python3
-from .utils import CommandPacket, ReceivePacket
+from .utils import (
+    Packet, 
+    CommandPacket, 
+    ReceivePacket,
+    USB2CANException,
+    ChecksumException,
+    PayloadTooLargeException,
+    InvalidFlagException,
+    InvalidStartFlagException,
+    InvalidEndFlagException
+)
 from .application_packet import (
     ApplicationPacket,
     ApplicationPacketWrongIdentifierException,
@@ -8,6 +18,7 @@ from .simulation import (
     SimulatedCANDevice,
     ExampleSimulatedEchoDevice,
     ExampleSimulatedAdderDevice,
+    SimulatedUSBtoCAN
 )
 from .device import CANDeviceHandle, ExampleEchoDeviceHandle, ExampleAdderDeviceHandle
 from .board import USBtoCANBoard

--- a/mil_common/drivers/mil_usb_to_can/mil_usb_to_can/application_packet.py
+++ b/mil_common/drivers/mil_usb_to_can/mil_usb_to_can/application_packet.py
@@ -1,33 +1,74 @@
 #! /usr/bin/env python3
+from __future__ import annotations
 import struct
+
+from typing import Any, Optional
 
 
 class ApplicationPacketWrongIdentifierException(Exception):
     """
     Exception thrown when the identifer for a MIL appliction level CAN packet
-    had a different identifer from what was expected
-    """
+    had a different identifer from what was expected.
 
-    def __init__(self, was, should_be):
+    Inherits from :class:`Exception`.
+    """
+    def __init__(self, was: Any, should_be: Any):
+        """
+        Attributes:
+            was (Any): A value representing what was found.
+            should_be (Any): What the found value should have been.
+        """
         super(ApplicationPacketWrongIdentifierException, self).__init__(
             "Expected identified '{}', got '{}'".format(should_be, was)
         )
 
 
-class ApplicationPacket(object):
-    """ """
+class ApplicationPacket:
+    """
+    One packet of data that is used to communicate with CAN devices.
 
-    def __init__(self, identifier, payload):
+    Attributes:
+        identifier (int): The identifier for the packet.
+        payload (bytes): The payload of bytes to be sent in the packet.
+    """
+    def __init__(self, identifier: int, payload: bytes):
         self.identifier = identifier
         self.payload = payload
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytes:
+        """
+        Packs the packet into a series of bytes using :meth:`struct.Struct.pack`. The identifier
+        is packed as an unsigned integer, while the payload of bytes is packed as
+        a sequence of bytes equal to the length of the payload.
+
+        Returns:
+            bytes: The packed bytes.
+        """
         return struct.pack(
             "B{}s".format(len(self.payload)), self.identifier, self.payload
         )
 
     @classmethod
-    def from_bytes(cls, data, expected_identifier=None):
+    def from_bytes(cls, data: bytes, expected_identifier: Optional[int] = None) -> ApplicationPacket:
+        """
+        Unpacks a series of packed bytes representing an application packet using
+        :meth:`struct.Struct.unpack`, which produces the packet identifier and array of data.
+        These values are then used to produce the new instance of the class.
+        
+        Args:
+            data (bytes): The packed packet.
+            expected_identifier (Optional[int]): The identifier that is expected to
+              result from the packet. If ``None``, then the identifier is not verified.
+              If this value is passed and the identifiers do not match, then the below
+              error is thrown.
+
+        Raises:
+            ApplicationPacketWrongIdentifierException: If the ```expected_identifier``
+              does not match the identifier found in the packet, then this is raised.
+
+        Returns:
+            ApplicationPacket: The data represented as an application packet.
+        """
         payload_len = len(data) - 1
         packet = cls(*struct.unpack("B{}s".format(payload_len), data))
         if expected_identifier is not None and expected_identifier != packet.identifier:

--- a/mil_common/drivers/mil_usb_to_can/mil_usb_to_can/device.py
+++ b/mil_common/drivers/mil_usb_to_can/mil_usb_to_can/device.py
@@ -1,36 +1,49 @@
 #!/usr/bin/python3
-import rospy
-import struct
 import random
 import string
-from .application_packet import ApplicationPacket
+import struct
+
+import rospy
 from rospy_tutorials.srv import AddTwoInts
 
-class CANDeviceHandle(object):
+from .application_packet import ApplicationPacket
+from .board import USBtoCANBoard
+
+
+class CANDeviceHandle:
     """
-    Helper class to allow developers to write handles for communication with a particular CAN device.
-    See ExampleCANDeviceHandle for an example of implementing one of these.
+    Base class to allow developers to write handles for communication with a
+    particular CAN device.
+
+    For examples of child classes of this class, see the ``device.py`` file in the
+    ``mil_usb_to_can`` package.
     """
 
-    def __init__(self, driver, device_id):
+    def __init__(self, driver: USBtoCANBoard, device_id: int):
         """
-        Creates a CANDeviceHandle.
-        @param driver: a USBtoCANBoard object that will be used for communication with the USB to CAN board
-        @param device_id: the CAN id of the device this class will handle
+        Args:
+                driver (USBtoCANBoard): Driver that is used to communicate with the board.
+                device_id (int): The CAN ID of the device this class will handle. Not currently used.
         """
         self._driver = driver
         self._device_id = device_id
 
-    def on_data(self, data):
+    def on_data(self, data: bytes):
         """
-        Called when data is received from the device this handle is registered for
+        Called when data is received from the device this handle is registered for.
+
+        Args:
+            data (bytes): The data received.
         """
         pass
 
-    def send_data(self, data, can_id=0):
+    def send_data(self, data: bytes, can_id: int = 0):
         """
-        Sends data to the device
-        @param data: the data payload to send to the device (string/bytes object)
+        Sends data to the device.
+
+        Args:
+            data (bytes): The data payload to send to the device.
+            can_id (int): The CAN device ID to send data to. Defaults to 0.
         """
         return self._driver.send_data(data, can_id=can_id)
 


### PR DESCRIPTION
This PR adds documentation for the `mil_usb_to_can` package. Closes #515.