### PR TITLE
Remove all Classes subheaders, replace headers with specific class names

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3236,8 +3236,8 @@ Utility Functions
 
 .. autofunction:: mil_tools.get_ch
 
-Classes
-^^^^^^^
+FPrintFactory
+^^^^^^^^^^^^^
 
 .. attributetable:: FprintFactory
 
@@ -3267,31 +3267,37 @@ Utility Functions
 Images
 ------
 
-Classes
-^^^^^^^
+BagCrawler
+^^^^^^^^^^
 
 .. attributetable:: BagCrawler
 
 .. autoclass:: BagCrawler
     :members:
 
+CvDebug
+^^^^^^^
 .. attributetable:: CvDebug
 
 .. autoclass:: CvDebug
     :members:
 
+Image_Publisher
+^^^^^^^^^^^^^^^
 .. attributetable:: Image_Publisher
 
 .. autoclass:: Image_Publisher
     :members:
 
+Image_Subscriber
+^^^^^^^^^^^^^^^^
 .. attributetable:: Image_Subscriber
 
 .. autoclass:: Image_Subscriber
     :members:
 
 StereoImageSubscriber
-~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^
 
 .. attributetable:: StereoImageSubscriber
 
@@ -3299,7 +3305,7 @@ StereoImageSubscriber
     :members:
 
 Plotter
-~~~~~~~
+^^^^^^^
 
 .. attributetable:: Plotter
 
@@ -3309,14 +3315,16 @@ Plotter
 Serial
 ------
 
-Classes
-^^^^^^^
+NoopSerial
+^^^^^^^^^^
 
 .. attributetable:: NoopSerial
 
 .. autoclass:: NoopSerial
     :members:
 
+SimulatedSerial
+^^^^^^^^^^^^^^^
 .. attributetable:: SimulatedSerial
 
 .. autoclass:: SimulatedSerial
@@ -3327,8 +3335,8 @@ txros
 
 .. currentmodule:: txros
 
-Classes
-^^^^^^^
+Goal
+^^^^
 
 .. attributetable:: Goal
 
@@ -3367,19 +3375,22 @@ Utility Functions
 
 .. autofunction:: make_ray
 
-Classes
-^^^^^^^
-
+VectorToMarker
+^^^^^^^^^^^^^^
 .. attributetable:: mil_ros_tools.vector_to_marker.VectorToMarker
 
 .. autoclass:: mil_ros_tools.vector_to_marker.VectorToMarker
     :members:
 
+ClickedPointRecorder
+^^^^^^^^^^^^^^^^^^^^
 .. attributetable:: nodes.clicked_point_recorder.ClickedPointRecorder
 
 .. autoclass:: nodes.clicked_point_recorder.ClickedPointRecorder
     :members:
 
+NetworkBroadcaster
+^^^^^^^^^^^^^^^^^^
 .. attributetable:: nodes.network_broadcaster.NetworkBroadcaster
 
 .. autoclass:: nodes.network_broadcaster.NetworkBroadcaster


### PR DESCRIPTION
Closes #591. Each subheader is replaced with the name of the class under the subheader.