### PR TITLE
Various C++ attribute table fixes in Alabaster

### DIFF
--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -6,6 +6,7 @@ import importlib
 import inspect
 import os
 import re
+import sphinx.errors
 from collections import OrderedDict, namedtuple
 
 from docutils import nodes
@@ -303,10 +304,14 @@ def process_cppattributetable(app, doctree: Node, fromdocname):
 
     # Find all relevant C++ functions and attributes
     current_section = None
+
+    # Throw error if user is attempting to put attribute table for enum class
+
     for node in doctree.traverse(siblings=True):
         if hasattr(node, "attributes"):
-            if all([c in node.attributes["classes"] for c in ["cpp", "class"]]) or all(
-                c in node.attributes["classes"] for c in ["cpp", "struct"]
+            if "cpp" in node.attributes["classes"] and any(
+                c in node.attributes["classes"]
+                for c in ["class", "struct"]
             ):
                 # Store current C++ struct or class section as namespace::ClassName or ClassName
                 current_section = node.children[0].astext()
@@ -327,7 +332,9 @@ def process_cppattributetable(app, doctree: Node, fromdocname):
             elif all([c in node.attributes["classes"] for c in ["cpp", "function"]]):
                 # Get the signature line of the function, where its name is stored
                 try:
-                    descriptions = [n.astext() for n in node[0][0].children if isinstance(n, Node)]
+                    descriptions = [
+                        n.astext() for n in node[0][0].children if isinstance(n, Node)
+                    ]
                 except IndexError:
                     continue
 
@@ -352,7 +359,9 @@ def process_cppattributetable(app, doctree: Node, fromdocname):
             elif all([c in node.attributes["classes"] for c in ["cpp", "var"]]):
                 # Try to get signature lines for C++ variables
                 try:
-                    descriptions = [n.astext() for n in node.children[0][0] if isinstance(n, Node)]
+                    descriptions = [
+                        n.astext() for n in node.children[0][0] if isinstance(n, Node)
+                    ]
                 except IndexError:
                     continue
 
@@ -377,6 +386,18 @@ def process_cppattributetable(app, doctree: Node, fromdocname):
 
         # Turn the table elements in a node
         table = attributetable("")
+
+        # Throw error if not found in list of classes
+        if target not in classes:
+            raise sphinx.errors.ExtensionError(
+                "No C++ class or struct was found matching the "
+                f"{target} target provided. Please ensure that this class is purely "
+                "a C++ class or struct and not any other data structure. Additionally, "
+                "ensure that proper documentation was able to be generated without "
+                "the attribute table being used. If an error occurred, please open "
+                "an issue on our GitHub repo."
+            )
+
         for label, subitems in classes[target].items():
             if not subitems:
                 continue

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -315,8 +315,13 @@ def process_cppattributetable(app, doctree: Node, fromdocname):
             ):
                 # Store current C++ struct or class section as namespace::ClassName or ClassName
                 current_section = node.children[0].astext()
+
+                # Remove class/struct prefix
                 current_section = re.sub(r"^.*(class )", "", current_section)
                 current_section = re.sub(r"^.*(struct )", "", current_section)
+
+                # Remove inheritance string
+                current_section = re.sub(r" : .*$", "", current_section)
 
                 # Store goto IDs for the current section
                 ids[current_section] = node.children[0].attributes["ids"][0]

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -276,6 +276,11 @@ TableElement = namedtuple("TableElement", "fullname label badge")
 
 
 def _parse_cpp_function_sig_children(children: List[Node]):
+    # Remove equal sign and everything after if found
+    if "=" in children:
+        equal_sign = children.index("=")
+        children = children[:equal_sign]
+
     # Remove unnecessary keywords
     to_remove = [" ", "const"]
     children[:] = [child for child in children if child not in to_remove]
@@ -284,10 +289,17 @@ def _parse_cpp_function_sig_children(children: List[Node]):
 
 
 def _parse_cpp_attribute_sig_children(children: List[Node]):
+    # Remove equal sign and everything after if found
     if "=" in children:
         equal_sign = children.index("=")
         children = children[:equal_sign]
 
+    # Remove array formatting
+    if "]" in children:
+        opening_bracket = children.index("[")
+        children = children[:opening_bracket]
+
+    print(children)
     children[:] = [child for child in children if child not in [" ", ""]]
     return children[-1]
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -4037,8 +4037,7 @@ PointColorStats
 
 PcdColorizer
 ^^^^^^^^^^^^
-.. TODO GH-612
-.. .. cppattributetable:: mil_vision::PcdColorizer
+.. cppattributetable:: mil_vision::PcdColorizer
 
 .. doxygenclass:: mil_vision::PcdColorizer
 
@@ -4090,8 +4089,7 @@ CameraModel
 
 ROSCameraStream
 ^^^^^^^^^^^^^^^
-.. TODO GH-612
-.. .. cppattributetable:: mil_vision::ROSCameraStream
+.. cppattributetable:: mil_vision::ROSCameraStream
 
 .. doxygenclass:: mil_vision::ROSCameraStream
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -4050,9 +4050,6 @@ SingleCloudProcessor
 
 PixelType
 ^^^^^^^^^
-.. TODO GH-613
-.. .. cppattributetable:: mil_vision::PixelType
-
 .. doxygenenum:: mil_vision::PixelType
 
 CameraFrame


### PR DESCRIPTION
This PR fixes multiple issues with the C++ attribute tables in the Alabaster docs refresh:

- #611 
- #612 
- #613 
- #614

Documentation that previously broke because of these features was updated to support these features.