### PR TITLE
Added getting_started link to SubjuGator page.Issue: #620

### DIFF
--- a/docs/subjugator/index.rst
+++ b/docs/subjugator/index.rst
@@ -6,7 +6,7 @@ This page provides general info about developing for
 competition for autonomous submarines. MIL has participated in RoboSub
 for 20+ years. Most code for this is hosted under SubjuGator/.
 
-*NOTE: Please go through the* `getting started guide </docs/development/getting_started>`__ 
+*NOTE: Please go through the* `getting started guide </docs/development/getting_started.md>`__ 
 *before going through this tutorial. We will assume you are currently in the development container
 running a tmux session.*
 

--- a/docs/subjugator/index.rst
+++ b/docs/subjugator/index.rst
@@ -6,7 +6,7 @@ This page provides general info about developing for
 competition for autonomous submarines. MIL has participated in RoboSub
 for 20+ years. Most code for this is hosted under SubjuGator/.
 
-*NOTE: Please go through the* `development guide </docs/development/development_guide>`__ 
+*NOTE: Please go through the* `getting started guide </docs/development/getting_started>`__ 
 *before going through this tutorial. We will assume you are currently in the development container
 running a tmux session.*
 


### PR DESCRIPTION
### WHY
Closes #620 

### What Changed
The main [SubjuGator](https://mil.readthedocs.io/en/latest/docs/subjugator/index.html) page in the docs had a link to the (now deprecated) [Development Guide](https://mil.readthedocs.io/en/latest/docs/development/development_guide.html)
This is now pointing to [Getting Started](https://mil.readthedocs.io/en/latest/docs/development/getting_started.html) instead.

Please check and comment for any further queries. I am new to the OSC world. 
Thank You.