### PR TITLE
Migrate the `sub8_thrust_and_kill_board` and add documentation to Alabaster

### DIFF
--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/__init__.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/__init__.py
@@ -1,4 +1,4 @@
-from handle import ThrusterAndKillBoard
-from simulation import ThrusterAndKillBoardSimulation
-from packets import ThrustPacket, KillMessage, HeartbeatMessage, StatusMessage
-from thruster import Thruster
+from .handle import ThrusterAndKillBoard
+from .simulation import ThrusterAndKillBoardSimulation
+from .packets import ThrustPacket, KillMessage, HeartbeatMessage, StatusMessage
+from .thruster import Thruster

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/handle.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/handle.py
@@ -1,88 +1,123 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import rospy
+from rospy.timer import TimerEvent
+from ros_alarms.msg import Alarm
 from mil_usb_to_can import CANDeviceHandle
 from .thruster import make_thruster_dictionary
-from .packets import ThrustPacket, KillMessage, HeartbeatMessage, StatusMessage, THRUST_SEND_ID, KILL_SEND_ID
-from std_srvs.srv import SetBool
+from .packets import (
+    ThrustPacket,
+    KillMessage,
+    HeartbeatMessage,
+    StatusMessage,
+    THRUST_SEND_ID,
+    KILL_SEND_ID,
+)
+from std_srvs.srv import SetBool, SetBoolRequest, SetBoolResponse
 from ros_alarms import AlarmBroadcaster, AlarmListener
 from sub8_msgs.msg import Thrust
 
 
 class ThrusterAndKillBoard(CANDeviceHandle):
-    '''
+    """
     Device handle for the thrust and kill board.
-    '''
+    """
 
     def __init__(self, *args, **kwargs):
         super(ThrusterAndKillBoard, self).__init__(*args, **kwargs)
         # Initialize thruster mapping from params
         self.thrusters = make_thruster_dictionary(
-            rospy.get_param('/thruster_layout/thrusters'))
+            rospy.get_param("/thruster_layout/thrusters")
+        )
         # Tracks last hw-kill alarm update
         self._last_hw_kill = None
         # Tracks last go status broadcasted
         self._last_go = None
         # Used to raise/clear hw-kill when board updates
-        self._kill_broadcaster = AlarmBroadcaster('hw-kill')
+        self._kill_broadcaster = AlarmBroadcaster("hw-kill")
         # Alarm broadaster for GO command
-        self._go_alarm_broadcaster = AlarmBroadcaster('go')
+        self._go_alarm_broadcaster = AlarmBroadcaster("go")
         # Listens to hw-kill updates to ensure another nodes doesn't manipulate it
         self._hw_kill_listener = AlarmListener(
-            'hw-kill', callback_funct=self.on_hw_kill)
+            "hw-kill", callback_funct=self.on_hw_kill
+        )
         # Provide service for alarm handler to set/clear the motherboard kill
         self._unkill_service = rospy.Service(
-            '/set_mobo_kill', SetBool, self.set_mobo_kill)
+            "/set_mobo_kill", SetBool, self.set_mobo_kill
+        )
         # Sends hearbeat to board
-        self._hearbeat_timer = rospy.Timer(
-            rospy.Duration(0.4), self.send_heartbeat)
+        self._hearbeat_timer = rospy.Timer(rospy.Duration(0.4), self.send_heartbeat)
         # Create a subscribe for thruster commands
         self._sub = rospy.Subscriber(
-            '/thrusters/thrust', Thrust, self.on_command, queue_size=10)
+            "/thrusters/thrust", Thrust, self.on_command, queue_size=10
+        )
 
-    def set_mobo_kill(self, req):
-        '''
-        Called on service calls to /set_mobo_kill, sending the approrpriate packet to the board
-        to unassert or assert to motherboard-origin kill
-        '''
-        self.send_data(KillMessage.create_kill_message(command=True, hard=False, asserted=req.data).to_bytes(),
-                       can_id=KILL_SEND_ID)
-        return {'success': True}
+    def set_mobo_kill(self, req: SetBoolRequest) -> SetBoolResponse:
+        """
+        Called on service calls to ``/set_mobo_kill``, sending the approrpriate
+        packet to the board to unassert or assert to motherboard-origin kill.
 
-    def send_heartbeat(self, timer):
-        '''
-        Send the special heartbeat packet when the timer triggers
-        '''
-        self.send_data(HeartbeatMessage.create().to_bytes(),
-                       can_id=KILL_SEND_ID)
+        Args:
+            req (SetBoolRequest): The service request.
 
-    def on_hw_kill(self, alarm):
-        '''
-        Update the classe's hw-kill alarm to the latest update
-        '''
+        Returns:
+            SetBoolResponse: The service response.
+        """
+        self.send_data(
+            KillMessage.create_kill_message(
+                command=True, hard=False, asserted=req.data
+            ).to_bytes(),
+            can_id=KILL_SEND_ID,
+        )
+        return SetBoolResponse(success=True)
+
+    def send_heartbeat(self, _: TimerEvent) -> None:
+        """
+        Send a special heartbeat packet. Called by a recurring timer set upon
+        initialization.
+        """
+        self.send_data(HeartbeatMessage.create().to_bytes(), can_id=KILL_SEND_ID)
+
+    def on_hw_kill(self, alarm: Alarm) -> None:
+        """
+        Update the classes' hw-kill alarm to the latest update.
+
+        Args:
+            alarm (:class:`~ros_alarms.msg._Alarm.Alarm`): The alarm message to update with.
+        """
         self._last_hw_kill = alarm
 
-    def on_command(self, msg):
-        '''
+    def on_command(self, msg: Thrust) -> None:
+        """
         When a thrust command message is received from the Subscriber, send the appropriate packet
-        to the board
-        '''
+        to the board.
+
+        Args:
+            msg (Thrust): The thrust message.
+        """
         for cmd in msg.thruster_commands:
             # If we don't have a mapping for this thruster, ignore it
             if cmd.name not in self.thrusters:
                 rospy.logwarn(
-                    'Command received for {}, but this is not a thruster.'.format(cmd.name))
+                    "Command received for {}, but this is not a thruster.".format(
+                        cmd.name
+                    )
+                )
                 continue
             # Map commanded thrust (in newetons) to effort value (-1 to 1)
             effort = self.thrusters[cmd.name].effort_from_thrust(cmd.thrust)
             # Send packet to command specified thruster the specified force
             packet = ThrustPacket.create_thrust_packet(
-                ThrustPacket.ID_MAPPING[cmd.name], effort)
+                ThrustPacket.ID_MAPPING[cmd.name], effort
+            )
             self.send_data(packet.to_bytes(), can_id=THRUST_SEND_ID)
 
-    def update_hw_kill(self, status):
-        '''
-        If needed, update the hw-kill alarm so it reflects the latest status from the board
-        '''
+    def update_hw_kill(self, status: StatusMessage) -> None:
+        """
+        If needed, update the hw-kill alarm so it reflects the latest status from the board.
+
+        Args:
+            status (StatusMessage): The status message.
+        """
         # Set serverity / problem message appropriately
         severity = 0
         message = ""
@@ -93,42 +128,94 @@ class ThrusterAndKillBoard(CANDeviceHandle):
             severity = 1
             reasons = []
             if status.switch_soft_kill:
-                reasons.append('switch')
+                reasons.append("switch")
             if status.mobo_soft_kill:
-                reasons.append('mobo')
+                reasons.append("mobo")
             if status.heartbeat_lost:
-                reasons.append('hearbeat')
-            message = 'Soft kill from: ' + ','.join(reasons)
+                reasons.append("hearbeat")
+            message = "Soft kill from: " + ",".join(reasons)
         raised = severity != 0
 
         # If the current status differs from the alarm, update the alarm
-        if self._last_hw_kill is None or self._last_hw_kill.raised != raised or \
-           self._last_hw_kill.problem_description != message or self._last_hw_kill.severity != severity:
+        if (
+            self._last_hw_kill is None
+            or self._last_hw_kill.raised != raised
+            or self._last_hw_kill.problem_description != message
+            or self._last_hw_kill.severity != severity
+        ):
             if raised:
                 self._kill_broadcaster.raise_alarm(
-                    severity=severity, problem_description=message)
+                    severity=severity, problem_description=message
+                )
             else:
-                self._kill_broadcaster.clear_alarm(
-                    severity=severity)
+                self._kill_broadcaster.clear_alarm(severity=severity)
 
-    def on_data(self, data):
-        '''
-        Parse the two bytes and raise kills according to the specs:
+    def on_data(self, data: bytes) -> None:
+        """
+        Parse the two bytes and raise kills according to a set of specifications
+        listed below.
 
-        First Byte => Kill trigger statuses (Asserted = 1, Unasserted = 0):
-            Bit 7: Hard kill status, changed by On/Off Hall effect switch. If this becomes 1, begin shutdown procedure
-            Bit 6: Overall soft kill status, 1 if any of the following flag bits are 1. This becomes 0 if all kills are cleared and the thrusters are done re-initializing
-            Bit 5: Hall effect soft kill flag
-            Bit 4: Mobo command soft kill flag
-            Bit 3: Heartbeat lost flag (times out after 1 s)
-            Bit 2-0: Reserved
-        Second Byte => Input statuses ("Pressed" = 1, "Unpressed" = 0) and thruster initializing status:
-            Bit 7: On (1) / Off (0) Hall effect switch status. If this becomes 0, the hard kill in the previous byte becomes 1.
-            Bit 6: Soft kill Hall effect switch status. If this is "pressed" = 1, bit 5 of previous byte is unkilled = 0. "Removing" the magnet will "unpress" the switch
-            Bit 5: Go Hall effect switch status. "Pressed" = 1, removing the magnet will "unpress" the switch
-            Bit 4: Thruster initializing status: This becomes 1 when the board is unkilling, and starts powering thrusters. After the "grace period" it becomes 0 and the overall soft kill status becomes 0. This flag also becomes 0 if killed in the middle of initializing thrusters.
-            Bit 3-0: Reserved
-        '''
+        Specifications of the first byte (where "asserted" is 1 and "unasserted" is 0):
+
+        +------------+-------------------------------------------+
+        | First Byte | Meaning                                   |
+        +============+===========================================+
+        | Bit 7      | Hard kill status, changed by the Hall     |
+        |            | Effect switch. If this becomes 1, the     |
+        |            | shutdown procedure begins.                |
+        +------------+-------------------------------------------+
+        | Bit 6      | The generalized soft kill status. Becomes |
+        |            | 1 if any of the specific soft kill flags  |
+        |            | become 1. Returns to 0 if all kills are   |
+        |            | cleared and the thrusters are done        |
+        |            | re-initializing.                          |
+        +------------+-------------------------------------------+
+        | Bit 5      | Soft kill flag for the Hall Effect sensor |
+        +------------+-------------------------------------------+
+        | Bit 4      | Motherboard command soft kill flag.       |
+        +------------+-------------------------------------------+
+        | Bit 3      | Soft kill indicating heartbeat was lost.  |
+        |            | Times out after one second.               |
+        +------------+-------------------------------------------+
+        | Bit 2      |                                           |
+        | Bit 1      | Reserved flags.                           |
+        | Bit 0      |                                           |
+        +------------+-------------------------------------------+
+
+        Specifications of the second byte (where "pressed" is 1 and "unpressed" is 0):
+
+        +-------------+-------------------------------------------+
+        | Second Byte | Meaning                                   |
+        +=============+===========================================+
+        | Bit 7       | Hard kill status representing the Hall    |
+        |             | Effect switch. If this becomes 0 ("on"),  |
+        |             | the hard kill in the previous byte        |
+        |             | becomes 1.                                |
+        +-------------+-------------------------------------------+
+        | Bit 6       | The soft kill status of the Hall Effect   |
+        |             | sensor. If this is "pressed" (1) then bit |
+        |             | 5 of the previous byte becomes "unkilled" |
+        |             | (0). Removing the magnet "unpresses" the  |
+        |             | switch.                                   |
+        +-------------+-------------------------------------------+
+        | Bit 5       | Go Hall Effect switch status. "Pressed"   |
+        |             | is 1, removing the magnet "unpresses" the |
+        |             | switch.                                   |
+        +-------------+-------------------------------------------+
+        | Bit 4       | Thruster initializing status. Becomes 1   |
+        |             | when the board is unkilling and starts    |
+        |             | powering thrusters. After the "grace      |
+        |             | period" it becomes 0 and the overall soft |
+        |             | kill status becomes 0. The flag also      |
+        |             | becomes 0 if killed in the middle of      |
+        |             | initializing thrusters.                   |
+        +-------------+-------------------------------------------+
+        | Bit 3       |                                           |
+        | Bit 2       |                                           |
+        | Bit 1       | Reserved flags.                           |
+        | Bit 0       |                                           |
+        +-------------+-------------------------------------------+
+        """
         status = StatusMessage.from_bytes(data)
         self.update_hw_kill(status)
 
@@ -136,8 +223,10 @@ class ThrusterAndKillBoard(CANDeviceHandle):
         if self._last_go is None or go != self._last_go:
             if go:
                 self._go_alarm_broadcaster.raise_alarm(
-                    problem_description="Go plug pulled!")
+                    problem_description="Go plug pulled!"
+                )
             else:
                 self._go_alarm_broadcaster.clear_alarm(
-                    problem_description="Go plug returned")
+                    problem_description="Go plug returned"
+                )
             self._last_go = go

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/packets.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/packets.py
@@ -10,11 +10,40 @@ KILL_SEND_ID = 0x11
 
 
 class KillMessage(ApplicationPacket):
-    '''
+    """
     Represents a packet sent to kill/thrust board which contains
-    a command or response related to kill status
-    '''
-    IDENTIFIER = ord('K')
+    a command or response related to kill status.
+
+    Inherits from :class:`~mil_usb_to_can.ApplicationPacket`.
+
+    .. container:: operations
+
+        .. describe:: str(x)
+
+            Pretty-prints the class name and each of the three packet attributes.
+
+    Attributes:
+        IDENTIFIER (int): The packet's identifier. Set equal to the ordinal value
+            of "K", or 75.
+        COMMAND (int): Identifier representing the packet as a command packet.
+            Equal to 67. This identifier should only be found in the first byte
+            of the payload.
+        RESPONSE (int): Identifier representing the packet as a response packet.
+            Equal to 82. This identifier should only be found in the first byte of
+            the payload.
+        HARD (int): Identifier representing the type of kill as a hard kill. Equal
+            to 72. This identifier is designed to be used in the second byte of the
+            payload.
+        SOFT (int): Identifier representing the type of kill as a soft kill. Equal
+            to 83. This identifier is designed to be used in the second byte of the
+            payload.
+        ASSERTED (int): Identifier equal to 65. This identifier is meant to be used
+            in the third byte of the payload.
+        UNASSERTED (int): Identifier equal to 85. This identifier is meant to be used
+            in the third byte of the payload.
+    """
+
+    IDENTIFIER = ord("K")
     COMMAND = 0x43
     RESPONSE = 0x52
     HARD = 0x48
@@ -24,49 +53,114 @@ class KillMessage(ApplicationPacket):
     PADDING = 0x00
 
     @classmethod
-    def create_kill_message(cls, command=False, hard=False, asserted=False):
+    def create_kill_message(cls, command: bool = False, hard: bool = False, asserted: bool = False):
+        """
+        Creates a kill message containing three bytes of information, specified
+        as parameters.
+
+        Args:
+            command (bool): Whether to make the kill message a command. If ``False``,
+                then the packet will represent a response.
+            hard (bool): Whether to make the packet kill type hard. If ``False``,
+                then the packet will represent a soft kill.
+            asserted (bool): Whether to make the packet asserted. If ``False``, then
+                an unasserted packet is generated.
+        """
         command_byte = cls.COMMAND if command else cls.RESPONSE
         hard_soft_byte = cls.HARD if hard else cls.SOFT
         assert_unassert_byte = cls.ASSERTED if asserted else cls.UNASSERTED
-        payload = struct.pack('BBBB', command_byte, hard_soft_byte, assert_unassert_byte, cls.PADDING)
+        payload = struct.pack(
+            "BBBB", command_byte, hard_soft_byte, assert_unassert_byte, cls.PADDING
+        )
         return cls(cls.IDENTIFIER, payload)
 
     @property
-    def is_command(self):
+    def is_command(self) -> bool:
+        """
+        Whether the packet represents a command.
+
+        Returns:
+            bool: The status of the packet's command/response type.
+        """
         return ord(self.payload[0]) == self.COMMAND
 
     @property
-    def is_response(self):
+    def is_response(self) -> bool:
+        """
+        Whether the packet represents a response.
+
+        Returns:
+            bool: The status of the packet's command/response type.
+        """
         return ord(self.payload[0]) == self.RESPONSE
 
     @property
-    def is_hard(self):
+    def is_hard(self) -> bool:
+        """
+        Whether the packet represents a hard kill.
+
+        Returns:
+            bool: The status of the packet's hard/soft kill type.
+        """
         return ord(self.payload[1]) == self.HARD
 
     @property
-    def is_soft(self):
+    def is_soft(self) -> bool:
+        """
+        Whether the packet represents a soft kill.
+
+        Returns:
+            bool: The status of the packet's hard/soft kill type.
+        """
         return ord(self.payload[1]) == self.SOFT
 
     @property
     def is_asserted(self):
+        """
+        Whether the packet represents an asserted packet.
+
+        Returns:
+            bool: The status of the packet's asserteed/unasserted type.
+        """
         return ord(self.payload[2]) == self.ASSERTED
 
     @property
     def is_unasserted(self):
+        """
+        Whether the packet represents an unasserted packet.
+
+        Returns:
+            bool: The status of the packet's asserteed/unasserted type.
+        """
         return ord(self.payload[2]) == self.UNASSERTED
 
     def __str__(self):
-        return 'KillMessage(command={}, hard={}, asserted={})'.format(self.is_command, self.is_hard, self.is_asserted)
+        return "KillMessage(command={}, hard={}, asserted={})".format(
+            self.is_command, self.is_hard, self.is_asserted
+        )
 
-KillStatus = namedtuple('KillStatus', ['heartbeat_lost', 'mobo_soft_kill',
-                                       'switch_soft_kill', 'soft_killed',
-                                       'hard_killed', 'thrusters_initializing',
-                                       'go_switch', 'soft_kill_switch',
-                                       'hard_kill_switch'])
+
+KillStatus = namedtuple(
+    "KillStatus",
+    [
+        "heartbeat_lost",
+        "mobo_soft_kill",
+        "switch_soft_kill",
+        "soft_killed",
+        "hard_killed",
+        "thrusters_initializing",
+        "go_switch",
+        "soft_kill_switch",
+        "hard_kill_switch",
+    ],
+)
+
+
 class StatusMessage(KillStatus):
-    BIT_MASK = KillStatus(1 << 3, 1 << 4, 1 << 5, 1 << 6, 1 << 7,
-                              1 << 11, 1 << 12, 1 << 13, 1 << 14)
-    STRUCT_FORMAT = '=h'
+    BIT_MASK = KillStatus(
+        1 << 3, 1 << 4, 1 << 5, 1 << 6, 1 << 7, 1 << 11, 1 << 12, 1 << 13, 1 << 14
+    )
+    STRUCT_FORMAT = "=h"
 
     def __init__(self, *args):
         super(StatusMessage, self).__init__(*args)
@@ -76,7 +170,7 @@ class StatusMessage(KillStatus):
         unpacked = struct.unpack(cls.STRUCT_FORMAT, data)[0]
         args = []
         for field in KillStatus._fields:
-                args.append(bool(unpacked & getattr(cls.BIT_MASK,field)))
+            args.append(bool(unpacked & getattr(cls.BIT_MASK, field)))
         return cls(*args)
 
     def to_bytes(self):
@@ -88,47 +182,120 @@ class StatusMessage(KillStatus):
 
 
 class HeartbeatMessage(ApplicationPacket):
-    '''
-    Represents the special hearbeat packet send to kill/thrust board
-    '''
-    IDENTIFIER = ord('H')
+    """
+    Represents the special hearbeat packet send to kill and thruster board.
+
+    Inherits from :class:`~mil_usb_to_can.ApplicationPacket`.
+
+    .. container:: operations
+
+        .. describe:: str(x)
+
+            Pretty-prints the class name.
+
+    Attributes:
+        IDENTIFIER (int): The packet identifier. Set equal to the ordinal value of
+            "H," or 72.
+    """
+
+    IDENTIFIER = ord("H")
 
     @classmethod
     def create(cls):
-        return cls(cls.IDENTIFIER, struct.pack('BB', ord('M'), 0))
+        """
+        Creates a new heartbeat message to be sent.
+        """
+        return cls(cls.IDENTIFIER, struct.pack("BB", ord("M"), 0))
 
     def __str__(self):
-        return 'HeartbeatMessage()'
+        return "HeartbeatMessage()"
+
 
 class ThrustPacket(ApplicationPacket):
-    '''
-    Represents a command send to the thrust/kill board to set
-    the PWM of a thruster
-    '''
-    IDENTIFIER = ord('T')
+    """
+    Represents a command send to the thrust/kill board to set the PWM of a thruster.
+
+    Inherits from :class:`~mil_usb_to_can.ApplicationPacket`.
+
+    .. container:: operations
+
+        .. describe:: str(x)
+
+            Pretty-prints the class name and each of the two packet attributes,
+            the thruster ID and the command.
+
+    Attributes:
+        IDENTIFIER (int): The packet identifier, equal to the ordinal value of "T,"
+            or 84.
+        ID_MAPPING (Dict[str, int]): A dictionary mapping 3-letter thruster codes
+            to their respective IDs:
+
+            +--------+------+
+            |  Name  |  ID  |
+            +========+======+
+            |  FLH   |  0   |
+            +--------+------+
+            |  FRH   |  1   |
+            +--------+------+
+            |  FLV   |  2   |
+            +--------+------+
+            |  FRV   |  3   |
+            +--------+------+
+            |  BLH   |  4   |
+            +--------+------+
+            |  BRH   |  5   |
+            +--------+------+
+            |  BLV   |  6   |
+            +--------+------+
+            |  BRV   |  7   |
+            +--------+------+
+    """
+
+    IDENTIFIER = ord("T")
     ID_MAPPING = {
-        'FLH': 0,
-        'FRH': 1,
-        'FLV': 2,
-        'FRV': 3,
-        'BLH': 4,
-        'BRH': 5,
-        'BLV': 6,
-        'BRV': 7,
+        "FLH": 0,
+        "FRH": 1,
+        "FLV": 2,
+        "FRV": 3,
+        "BLH": 4,
+        "BRH": 5,
+        "BLV": 6,
+        "BRV": 7,
     }
 
     @classmethod
-    def create_thrust_packet(cls, thruster_id, command):
-        payload = struct.pack('=Bf', thruster_id, command)
+    def create_thrust_packet(cls, thruster_id: int, command: float):
+        """
+        Creates a thruster packet given an ID and command.
+
+        Args:
+            thruster_id (int): The ID of the thruster to create a packet for.
+            command (float): The command to associate with the packet.
+        """
+        payload = struct.pack("=Bf", thruster_id, command)
         return cls(cls.IDENTIFIER, payload)
 
     @property
-    def thruster_id(self):
-        return struct.unpack('B', self.payload[0])[0]
+    def thruster_id(self) -> int:
+        """
+        The thruster ID associated with the packet.
+
+        Returns:
+            int: The ID.
+        """
+        return struct.unpack("B", self.payload[0])[0]
 
     @property
-    def command(self):
-        return struct.unpack('f', self.payload[1:])[0]
+    def command(self) -> float:
+        """
+        The command associated with the packet.
+
+        Returns:
+            float: The associated command.
+        """
+        return struct.unpack("f", self.payload[1:])[0]
 
     def __str__(self):
-        return 'ThrustPacket(thruster_id={}, command={})'.format(self.thruster_id, self.command)
+        return "ThrustPacket(thruster_id={}, command={})".format(
+            self.thruster_id, self.command
+        )

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/packets.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/packets.py
@@ -53,7 +53,9 @@ class KillMessage(ApplicationPacket):
     PADDING = 0x00
 
     @classmethod
-    def create_kill_message(cls, command: bool = False, hard: bool = False, asserted: bool = False):
+    def create_kill_message(
+        cls, command: bool = False, hard: bool = False, asserted: bool = False
+    ):
         """
         Creates a kill message containing three bytes of information, specified
         as parameters.

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/simulation.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/simulation.py
@@ -1,15 +1,23 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 from mil_usb_to_can import SimulatedCANDevice
-from .packets import ThrustPacket, KillMessage, HeartbeatMessage, StatusMessage, THRUST_SEND_ID, KILL_SEND_ID
+from .packets import (
+    ThrustPacket,
+    KillMessage,
+    HeartbeatMessage,
+    StatusMessage,
+    THRUST_SEND_ID,
+    KILL_SEND_ID,
+)
 import rospy
 from std_srvs.srv import SetBool
 
 
 class ThrusterAndKillBoardSimulation(SimulatedCANDevice):
-    '''
+    """
     Serial simulator for the thruster and kill board,
-    providing services to simulate physical plug connections/disconnections
-    '''
+    providing services to simulate physical plug connections/disconnections.
+    """
+
     HEARTBEAT_TIMEOUT_SECONDS = rospy.Duration(1.0)
 
     def __init__(self, *args, **kwargs):
@@ -21,40 +29,80 @@ class ThrusterAndKillBoardSimulation(SimulatedCANDevice):
         self._last_heartbeat = None
         super(ThrusterAndKillBoardSimulation, self).__init__(*args, **kwargs)
         self._update_timer = rospy.Timer(rospy.Duration(1), self.send_updates)
-        self._soft_kill = rospy.Service('/simulate_soft_kill', SetBool, self.set_soft_kill)
-        self._hard_kill = rospy.Service('/simulate_hard_kill', SetBool, self.set_hard_kill)
-        self._go_srv = rospy.Service('/simulate_go', SetBool, self._on_go_srv)
+        self._soft_kill = rospy.Service(
+            "/simulate_soft_kill", SetBool, self.set_soft_kill
+        )
+        self._hard_kill = rospy.Service(
+            "/simulate_hard_kill", SetBool, self.set_hard_kill
+        )
+        self._go_srv = rospy.Service("/simulate_go", SetBool, self._on_go_srv)
 
     def _on_go_srv(self, req):
         self.go_button = req.data
-        return {'success': True}
+        return {"success": True}
 
     def set_soft_kill(self, req):
         self.soft_kill_plug_pulled = req.data
-        return {'success': True}
+        return {"success": True}
 
     def set_hard_kill(self, req):
         self.hard_kill_plug_pulled = req.data
-        return {'success': True}
+        return {"success": True}
 
     @property
-    def hard_killed(self):
+    def hard_killed(self) -> bool:
+        """
+        Whether the board was hard killed.
+
+        Returns:
+            bool: The status of the board being hard killed.
+        """
         return self.hard_kill_mobo or self.hard_kill_plug_pulled
 
     @property
-    def heartbeat_timedout(self):
-        return self._last_heartbeat is None or (rospy.Time.now() - self._last_heartbeat) > self.HEARTBEAT_TIMEOUT_SECONDS
+    def heartbeat_timedout(self) -> bool:
+        """
+        Whether the heartbeat timed out.
+
+        Returns:
+            bool: The status of the heartbeat timing out.
+        """
+        return (
+            self._last_heartbeat is None
+            or (rospy.Time.now() - self._last_heartbeat)
+            > self.HEARTBEAT_TIMEOUT_SECONDS
+        )
 
     @property
     def soft_killed(self):
-        return self.soft_kill_plug_pulled or self.soft_kill_mobo or self.heartbeat_timedout
+        """
+        Whether the board was soft killed.
+
+        Returns:
+            bool: The status of the board being soft killed.
+        """
+        return (
+            self.soft_kill_plug_pulled or self.soft_kill_mobo or self.heartbeat_timedout
+        )
 
     def send_updates(self, *args):
-        status = StatusMessage(self.heartbeat_timedout, self.soft_kill_mobo, self.soft_kill_plug_pulled, self.soft_killed, self.hard_killed, False, self.go_button,
-                               not self.soft_kill_plug_pulled, not self.hard_kill_plug_pulled)
+        """
+        Sends data about the class in a new status message.
+        """
+        status = StatusMessage(
+            self.heartbeat_timedout,
+            self.soft_kill_mobo,
+            self.soft_kill_plug_pulled,
+            self.soft_killed,
+            self.hard_killed,
+            False,
+            self.go_button,
+            not self.soft_kill_plug_pulled,
+            not self.hard_kill_plug_pulled,
+        )
         self.send_data(status.to_bytes())
 
-    def on_data(self, data, can_id):
+    def on_data(self, data: bytes, can_id: int):
         assert can_id == THRUST_SEND_ID or can_id == KILL_SEND_ID
         if KillMessage.IDENTIFIER == ord(data[0]):
             packet = KillMessage.from_bytes(data)
@@ -71,4 +119,4 @@ class ThrusterAndKillBoardSimulation(SimulatedCANDevice):
             packet = HeartbeatMessage.from_bytes(data)
             self._last_heartbeat = rospy.Time.now()
         else:
-            assert False, 'No recognized identifer'
+            assert False, "No recognized identifer"

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/thruster.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/thruster.py
@@ -1,38 +1,67 @@
 from numpy import polyval
 from numpy import clip
 
+from typing import Dict, Any
+
 
 def make_thruster_dictionary(dictionary):
-    '''
-    Make a dictionary mapping thruster names to Thruster objects
-    '''
+    """
+    Make a dictionary mapping thruster names to :class:`Thruster` objects.
+    """
     ret = {}
-    for thruster, content in dictionary.iteritems():
+    for thruster, content in dictionary.items():
         ret[thruster] = Thruster.from_dict(content)
     return ret
 
 
-class Thruster(object):
-    '''
-    Models the force (thrust) to PWM (effort) of a thruster
-    '''
+class Thruster:
+    """
+    Models the force (thrust) to PWM (effort) of a thruster.
+
+    Attributes:
+        forward_calibration (???): ???
+        backward_calibration (???): ???
+    """
+
     def __init__(self, forward_calibration, backward_calibration):
         self.forward_calibration = forward_calibration
         self.backward_calibration = backward_calibration
 
     @classmethod
-    def from_dict(cls, data):
-        forward_calibration = data['calib']['forward']
-        backward_calibration = data['calib']['backward']
+    def from_dict(cls, data: Dict[str, Dict[str, Any]]):
+        """
+        Constructs the class from a dictionary. The dictionary should be formatted
+        as so:
+
+        .. code-block:: python3
+
+            {
+                "calib": {
+                    "forward": ...,
+                    "backward": ...,
+                }
+            }
+
+        Args:
+            data (Dict[str, Dict[str, Any]]): The dictionary containing the initialization info.
+        """
+        forward_calibration = data["calib"]["forward"]
+        backward_calibration = data["calib"]["backward"]
         return cls(forward_calibration, backward_calibration)
 
-    def effort_from_thrust_unclipped(self, thrust):
+    def effort_from_thrust_unclipped(self, thrust: Any):
         if thrust < 0:
             return polyval(self.backward_calibration, thrust)
         else:
             return polyval(self.forward_calibration, thrust)
 
-    def effort_from_thrust(self, thrust):
+    def effort_from_thrust(self, thrust: Any):
+        """
+        Attempts to find the effort from a particular value of thrust.
+
+        Args:
+            thrust (???): The amount of thrust.
+        """
         unclipped = self.effort_from_thrust_unclipped(thrust)
         # Theoritically can limit to .66 under 16V assumptions or .5 under 12V assumptions... So do both (.5 + 66)/2
-        return clip(unclipped, -.58, .58)
+        return clip(unclipped, -0.58, 0.58)

--- a/docs/subjugator/reference.rst
+++ b/docs/subjugator/reference.rst
@@ -148,3 +148,17 @@ ThrustPacket
 
 .. autoclass:: sub8_thrust_and_kill_board.ThrustPacket
     :members:
+
+ThrusterAndKillBoardSimulation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. attributetable:: sub8_thrust_and_kill_board.ThrusterAndKillBoardSimulation
+
+.. autoclass:: sub8_thrust_and_kill_board.ThrusterAndKillBoardSimulation
+    :members:
+
+Thruster
+^^^^^^^^
+.. attributetable:: sub8_thrust_and_kill_board.Thruster
+
+.. autoclass:: sub8_thrust_and_kill_board.Thruster
+    :members:

--- a/docs/subjugator/reference.rst
+++ b/docs/subjugator/reference.rst
@@ -5,6 +5,43 @@ Below is the reference documentation for the code on our submarine robot, SubjuG
 The following systems are relevant only to this robot, and no other robot. However,
 hyperlinks may link to systems on other robots.
 
+Messages
+--------
+
+Thrust
+^^^^^^
+.. attributetable:: sub8_msgs.msg._Thrust.Thrust
+
+.. class:: sub8_msgs.msg._Thrust.Thrust
+
+    Message type indicating commands for each thruster.
+
+    .. attribute:: thruster_commands
+
+        The commands for the thrusters.
+
+        :type: List[:class:`~sub8_msgs.msg._ThrusterCmd.ThrusterCmd`]
+
+ThrusterCmd
+^^^^^^^^^^^
+.. attributetable:: sub8_msgs.msg._ThrusterCmd.ThrusterCmd
+
+.. class:: sub8_msgs.msg._ThrusterCmd.ThrusterCmd
+
+    A command for a specific thruster.
+
+    .. attribute:: thrust
+
+        The amount of thrust for the specific thruster.
+
+        :type: :class:`float`
+
+    .. attribute:: name
+
+        The name of the thruster.
+
+        :type: :class:`str`
+
 Services
 --------
 
@@ -79,4 +116,14 @@ FeedbackMessage
 .. attributetable:: sub8_actuator_board.FeedbackMessage
 
 .. autoclass:: sub8_actuator_board.FeedbackMessage
+    :members:
+
+Thrust and Kill Board
+---------------------
+
+ThrusterAndKillBoard
+^^^^^^^^^^^^^^^^^^^^
+.. attributetable:: sub8_thrust_and_kill_board.ThrusterAndKillBoard
+
+.. autoclass:: sub8_thrust_and_kill_board.ThrusterAndKillBoard
     :members:

--- a/docs/subjugator/reference.rst
+++ b/docs/subjugator/reference.rst
@@ -127,3 +127,24 @@ ThrusterAndKillBoard
 
 .. autoclass:: sub8_thrust_and_kill_board.ThrusterAndKillBoard
     :members:
+
+KillMessage
+^^^^^^^^^^^
+.. attributetable:: sub8_thrust_and_kill_board.KillMessage
+
+.. autoclass:: sub8_thrust_and_kill_board.KillMessage
+    :members:
+
+HeartbeatMessage
+^^^^^^^^^^^^^^^^
+.. attributetable:: sub8_thrust_and_kill_board.HeartbeatMessage
+
+.. autoclass:: sub8_thrust_and_kill_board.HeartbeatMessage
+    :members:
+
+ThrustPacket
+^^^^^^^^^^^^
+.. attributetable:: sub8_thrust_and_kill_board.ThrustPacket
+
+.. autoclass:: sub8_thrust_and_kill_board.ThrustPacket
+    :members:


### PR DESCRIPTION
This PR migrates the `sub8_thrust_and_kill_board` to Python 3, adding support for ROS Noetic. Furthermore, documentation has been added in Alabaster for classes/methods found in this package.