### PR TITLE
Migrate the `mil_pneumatic_actuator` package to Python 3, add documentation

### DIFF
--- a/docs/design/design.rst
+++ b/docs/design/design.rst
@@ -7,3 +7,4 @@ Some technical info on various design:
 
   odom_estimator (Kalman filter) <odom_estimator/odom_estimator>
   Passive Sonar <passive_sonar/passive_sonar>
+  MIL Pneumatic Actuator <pneumatic_board.md>

--- a/docs/design/pneumatic_board.md
+++ b/docs/design/pneumatic_board.md
@@ -1,0 +1,36 @@
+# MIL's Pneumatic Board
+
+The pneumatic board is responsible for controlling several valves used to power
+various systems. The board was created by Daniel Volya, a former MIL member, who
+is now on his way to achieveing a PhD.
+
+## Raw Communication
+To send bytes: Send the command (as a byte), then send the byte XOR with `0xFF` (checksum).
+To receive bytes: Receive the byte (response), then receive the byte XOR with `0xFF` (checksum).
+
+The opcodes used by the board include:
+|  Opcode  |  Command                                    |
+|:---------|--------------------------------------------:|
+|  `0x10`  |  Send a ping to the board                   |
+|  `0x20`  |  Open valve (to allow air flow)             |
+|  `0x30`  |  Close valve (to disallow air flow)         |
+|  `0x40`  |  Read a switch                              |
+
+### Intended Operations
+* To 'ping' board (check if board is operational): send 0x10, if operational,
+  will reply with 0x11.
+* To open valve (allow air flow): send 0x20 + valve number
+  (ex. 0x20 + 0x04 (valve #4) = 0x24 <-- byte to send), will reply with 0x01.
+* To close valve (prevent air flow): send 0x30 + valve number
+  (ex. 0x30 + 0x0B (valve #11) = 0x3B <-- byte to send),will reply with 0x00.
+* To read switch: send 0x40 + switch number
+  (ex. 0x40 + 0x09 (valve #9) = 0x49 <-- byte to send), will reply with 0x00
+  if switch is open (not pressed) or 0x01 if switch is closed (pressed).
+
+## Interface through ROS
+
+In 2018, Kevin Allen, a former MIL member developed a bridge between ROS and the board.
+The class responsible for this interface is {class}`mil_pneumatic_actuator.PnuematicActuatorDriver`.
+
+This class provides several methods for completing all operations needed to control
+the board.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -4124,3 +4124,41 @@ POIServer
 
 .. autoclass:: mil_poi.POIServer
     :members:
+
+Pneumatic Actuator Board
+------------------------
+
+Exceptions
+^^^^^^^^^^
+.. autoclass:: mil_pneumatic_actuator.PnuematicActuatorDriverError
+    :members:
+
+.. autoclass:: mil_pneumatic_actuator.PnuematicActuatorDriverChecksumError
+    :members:
+
+.. autoclass:: mil_pneumatic_actuator.PnuematicActuatorDriverResponseError
+    :members:
+
+.. autoclass:: mil_pneumatic_actuator.PnuematicActuatorTimeoutError
+    :members:
+
+PneumaticActuatorDriver
+^^^^^^^^^^^^^^^^^^^^^^^
+.. attributetable:: mil_pneumatic_actuator.PnuematicActuatorDriver
+
+.. autoclass:: mil_pneumatic_actuator.PnuematicActuatorDriver
+    :members:
+   
+Pneumatic Board Constants
+^^^^^^^^^^^^^^^^^^^^^^^^^
+.. attributetable:: mil_pneumatic_actuator.Constants
+
+.. autoclass:: mil_pneumatic_actuator.Constants
+    :members:
+
+SimulatedPnuematicActuatorBoard
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. attributetable:: mil_pneumatic_actuator.SimulatedPnuematicActuatorBoard
+
+.. autoclass:: mil_pneumatic_actuator.SimulatedPnuematicActuatorBoard
+    :members:

--- a/mil_common/drivers/mil_pneumatic_actuator/mil_pneumatic_actuator/__init__.py
+++ b/mil_common/drivers/mil_pneumatic_actuator/mil_pneumatic_actuator/__init__.py
@@ -1,3 +1,3 @@
-from board import *
-from simulated_board import *
-from constants import Constants
+from .board import *
+from .constants import Constants
+from .simulated_board import *

--- a/mil_common/drivers/mil_pneumatic_actuator/mil_pneumatic_actuator/board.py
+++ b/mil_common/drivers/mil_pneumatic_actuator/mil_pneumatic_actuator/board.py
@@ -1,83 +1,109 @@
-#!/usr/bin/env python
-from mil_ros_tools import thread_lock
-from simulated_board import SimulatedPnuematicActuatorBoard
-from constants import Constants
+#!/usr/bin/env python3
 import threading
+from typing import Optional
+
 import serial
+from mil_ros_tools import thread_lock
+
+from .constants import Constants
+from .simulated_board import SimulatedPnuematicActuatorBoard
 
 lock = threading.Lock()
 
 
 class PnuematicActuatorDriverError(Exception):
+    """
+    The base exception class for all exceptions/errors related to the Pneumatic
+    Actuator Board.
+
+    Inherits from :class:`Exception`.
+    """
     def __init__(self, message):
-        super(PnuematicActuatorDriverError, self).__init__('Actuator board: ' + message)
+        super(PnuematicActuatorDriverError, self).__init__("Actuator board: " + message)
 
 
 class PnuematicActuatorDriverChecksumError(PnuematicActuatorDriverError):
+    """
+    Exception representing an invalid checksum.
+
+    Inherits from :class:`PnuematicActuatorDriverError`.
+    """
     def __init__(self, checksum_is, checksum_should_be):
-        message = 'Invalid checksum. Recievied {}, should be {}'.format(hex(checksum_is), hex(checksum_should_be))
+        message = "Invalid checksum. Recievied {}, should be {}".format(
+            hex(checksum_is), hex(checksum_should_be)
+        )
         super(PnuematicActuatorDriverChecksumError, self).__init__(message)
 
 
 class PnuematicActuatorDriverResponseError(PnuematicActuatorDriverError):
+    """
+    Exception representing an invalid response.
+
+    Inherits from :class:`PnuematicActuatorDriverError`.
+    """
     def __init__(self, received, expected):
-        message = 'Unexpected response. Expected {}, recieved {}'.format(hex(received), hex(expected))
+        message = "Unexpected response. Expected {}, recieved {}".format(
+            hex(received), hex(expected)
+        )
         super(PnuematicActuatorDriverResponseError, self).__init__(message)
 
 
 class PnuematicActuatorTimeoutError(PnuematicActuatorDriverError):
+    """
+    Exception representing a serial timeout experienced by the board.
+
+    Inherits from :class:`PnuematicActuatorDriverError`.
+    """
     def __init__(self):
-        message = 'Serial timout'
+        message = "Serial timout"
         super(PnuematicActuatorTimeoutError, self).__init__(message)
 
 
-class PnuematicActuatorDriver(object):
+class PnuematicActuatorDriver:
+    """
+    Allows high level ROS code to interface with Daniel's pneumatics board.
 
-    '''
-    Allows high level ros code to interface with Daniel's pneumatics board.
+    For the dropper and grabber systems, call service with ``True`` or ``False``
+    to open or close. For the shooter system, sending a ``True`` signal will
+    pulse the valve.
 
-    For dropper and grabber, call service with True or False to open or close.
-    For shooter, sending a True signal will pulse the valve.
+    Futher information on the board's communication protocol can be found in the
+    design documentation.
+    """
+    # TODO: Add a function to try and reconnect to the serial port if we lose connection.
 
-    TODO: Add a function to try and reconnect to the serial port if we lose connection.
-
-    Infomation on communication protcol:
-
-    Sending bytes: send byte (command), then send byte XOR w/ 0xFF (checksum)
-    Receiving bytes: receive byte (response), then receive byte XOR w/ 0xFF (checksum)
-
-    Base opcodes:
-    - 0x10 ping
-    - 0x20 open valve (allow air flow)
-    - 0x30 close valve (prevent air flow)
-    - 0x40 read switch
-
-    - To 'ping' board (check if board is operational): send 0x10, if operational,
-      will reply with 0x11.
-
-    - To open valve (allow air flow): send 0x20 + valve number
-      (ex. 0x20 + 0x04 (valve #4) = 0x24 <-- byte to send), will reply with 0x01.
-
-    - To close valve (prevent air flow): send 0x30 + valve number
-      (ex. 0x30 + 0x0B (valve #11) = 0x3B <-- byte to send),will reply with 0x00.
-
-    - To read switch: send 0x40 + switch number
-      (ex. 0x40 + 0x09 (valve #9) = 0x49 <-- byte to send), will reply with 0x00
-      if switch is open (not pressed) or 0x01 if switch is closed (pressed).
-    '''
-    def __init__(self, port, baud=9600, simulated=False):
+    def __init__(self, port: str, baud: int = 9600, simulated: bool = False):
+        """
+        Args:
+            port (str): The nname of the board to establish a serial connection to.
+            baud (int): The baud rate to establish the serial connection at.
+            simulated (bool): Whether to use a simulated actuator board class
+                or an interface to the physical board.
+        """
         if simulated:
             self.ser = SimulatedPnuematicActuatorBoard()
         else:
-            self.ser = serial.Serial(port=port, baudrate=baud, timeout=2.)
+            self.ser = serial.Serial(port=port, baudrate=baud, timeout=2.0)
         self.ser.flushInput()
 
     @classmethod
-    def _verify_checksum(cls, byte, checksum):
+    def _verify_checksum(cls, byte: int, checksum: int) -> None:
+        """
+        Verifies that two checksums are equivalent. If they are not equivalent,
+        then an exception is raised. Otherwise, ``None`` is implicitly returned.
+        """
         if not Constants.verify_checksum(byte, checksum):
-            raise PnuematicActuatorDriverChecksumError(checksum, Constants.create_checksum(byte))
+            raise PnuematicActuatorDriverChecksumError(
+                checksum, Constants.create_checksum(byte)
+            )
 
-    def _get_response(self):
+    def _get_response(self) -> int:
+        """
+        Internal method to return only the desired data sent by the actuator board.
+
+        Returns:
+            int: The response sent by the board.
+        """
         data = self.ser.read(2)
         if len(data) != 2:
             raise PnuematicActuatorTimeoutError()
@@ -88,7 +114,11 @@ class PnuematicActuatorDriver(object):
         return data
 
     @thread_lock(lock)
-    def _send_request(self, byte, expected_response=None):
+    def _send_request(self, byte: int, expected_response: Optional[int] = None) -> int:
+        """
+        Internal method which sends some data and compares it to the expected
+        response (if desired) before returning it to the caller.
+        """
         data = Constants.serialize_packet(byte)
         self.ser.write(data)
         response = self._get_response()
@@ -96,23 +126,105 @@ class PnuematicActuatorDriver(object):
             raise PnuematicActuatorDriverResponseError(response, expected_response)
         return response
 
-    def open_port(self, port):
+    def open_port(self, port: int) -> int:
+        """
+        Opens a particular port.
+
+        Args:
+            port (int): The port to open.
+
+        Raises:
+            PnuematicActuatorDriverResponseError: The expected response from the board
+                was not received.
+            PnuematicActuatorDriverChecksumError: The checksum expected and the checksum
+                received were not the same. The board may be malfunctioning or the
+                communication with the board may be disrupted.
+
+        Returns:
+            int: The response from the board, which is frequently a standard hexadecimal value
+                indicating that the board opened the valve at the desired port.
+                This value is equal to :attr:`mil_pneumatic_actuator.Constants.OPEN_RESPONSE`.
+        """
         byte = Constants.OPEN_REQUEST_BASE + port
         return self._send_request(byte, Constants.OPEN_RESPONSE)
 
-    def close_port(self, port):
+    def close_port(self, port: int) -> int:
+        """
+        Closes a particular port.
+
+        Args:
+            port (int): The port to close.
+
+        Raises:
+            PnuematicActuatorDriverResponseError: The expected response from the board
+                was not received.
+            PnuematicActuatorDriverChecksumError: The checksum expected and the checksum
+                received were not the same. The board may be malfunctioning or the
+                communication with the board may be disrupted.
+
+        Returns:
+            int: The response from the board, which is frequently a standard hexadecimal value
+                indicating that the board closed the valve at the desired port.
+                This value is equal to :attr:`mil_pneumatic_actuator.Constants.CLOSE_RESPONSE`.
+        """
         byte = Constants.CLOSE_REQUEST_BASE + port
         return self._send_request(byte, Constants.CLOSE_RESPONSE)
 
-    def set_port(self, port, do_open):
+    def set_port(self, port: int, do_open: bool) -> int:
+        """
+        Sets the data at a particular port to opened/closed. This does not depend
+        on the internal state of the port when called, ie, if you request a port to
+        be closed, and the port is already closed, then the response is sent anyways.
+
+        Args:
+            port (int): The specific port to open/close.
+            do_open (bool): Whether to open the port. If ``False``, then the port
+                is closed.
+
+        Raises:
+            PnuematicActuatorDriverResponseError: The expected response from the board
+                was not received.
+            PnuematicActuatorDriverChecksumError: The checksum expected and the checksum
+                received were not the same. The board may be malfunctioning or the
+                communication with the board may be disrupted.
+        """
         if do_open:
             return self.open_port(port)
         else:
             return self.close_port(port)
 
-    def get_port(self, port):
+    def get_port(self, port: int) -> int:
+        """
+        Reads the data at a specific port.
+
+        Args:
+            port (int): The port to read from.
+
+        Raises:
+            PnuematicActuatorDriverResponseError: The expected response from the board
+                was not received.
+            PnuematicActuatorDriverChecksumError: The checksum expected and the checksum
+                received were not the same. The board may be malfunctioning or the
+                communication with the board may be disrupted.
+
+        Returns:
+            int: The response served by the board.
+        """
         byte = Constants.READ_REQUEST_BASE + port
         return self._send_request(byte)
 
-    def ping(self):
+    def ping(self) -> int:
+        """
+        Sends a ping message to the board and returns the response.
+
+        Raises:
+            PnuematicActuatorDriverResponseError: The expected response from the board
+                was not received.
+            PnuematicActuatorDriverChecksumError: The checksum expected and the checksum
+                received were not the same. The board may be malfunctioning or the
+                communication with the board may be disrupted.
+
+        Returns:
+            int: The response from the board.
+        """
         return self._send_request(Constants.PING_REQUEST, Constants.PING_RESPONSE)

--- a/mil_common/drivers/mil_pneumatic_actuator/mil_pneumatic_actuator/constants.py
+++ b/mil_common/drivers/mil_pneumatic_actuator/mil_pneumatic_actuator/constants.py
@@ -1,12 +1,28 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import struct
+from typing import Tuple
 
 
-class Constants(object):
-    '''
-    Constant codes and functions used in both the driver and the simulated
-    board.
-    '''
+class Constants:
+    """
+    Constant codes and functions used in both the driver and the simulated board.
+
+    Attributes:
+        OPEN_REQUEST_BASE (int): A constant representing a request to the board to open a valve.
+            Currently set to ``0x20``.
+        OPEN_RESPONSE (int): A constant representing a response from the board when the open
+            request is sent. Currently set to ``0x01``.
+        CLOSE_REQUEST_BASE (int): A constant representing a request to the board to close a valve.
+            Currently set to ``0x30``.
+        CLOSE_RESPONSE (int): A constant representing a response from the board when the close
+            request is sent. Currently set to ``0x00``.
+        READ_REQUEST_BASE (int): A constant representing a request to the board to read
+            the value of a valve. Currently set to ``0x40``.
+        PING_REQUEST (int): A constant representing a ping request. Currently set to ``0x10``.
+        PING_RESPONSE (int): A constant representing a response from the board when the ping
+            request is sent. Currently set to ``0x11``.
+        CHECKSUM_CODE (int): The checksum code used by the board. Currently sent to ``0xFF``.
+    """
     OPEN_REQUEST_BASE = 0x20
     OPEN_RESPONSE = 0x01
     CLOSE_REQUEST_BASE = 0x30
@@ -17,17 +33,51 @@ class Constants(object):
     CHECKSUM_CODE = 0xFF
 
     @classmethod
-    def create_checksum(cls, byte):
+    def create_checksum(cls, byte: int) -> int:
+        """
+        Creates a checksum given a piece of data. The checksum is calculated through
+        the XOR operation.
+
+        Args:
+            byte (int): The data to compute the checksum on.
+
+        Returns:
+            int: The checksum.
+        """
         return byte ^ cls.CHECKSUM_CODE
 
     @classmethod
-    def verify_checksum(cls, byte, checksum):
+    def verify_checksum(cls, byte: int, checksum: int) -> bool:
+        """
+        Verifies that two checksums are the same.
+
+        Args:
+            byte (int): The data to verify the constructed checksum of.
+            checksum (int): The checksum to validate the constructed checksum against.
+
+        Returns:
+            bool: Whether the two checksums are the same.
+        """
         return checksum == cls.create_checksum(byte)
 
     @classmethod
-    def serialize_packet(cls, byte):
-        return struct.pack('BB', byte, cls.create_checksum(byte))
+    def serialize_packet(cls, byte: int) -> bytes:
+        """
+        Serializes a piece of data (an integer) into a bytes object.
+
+        Returns:
+            bytes: The serialized packet.
+        """
+        return struct.pack("BB", byte, cls.create_checksum(byte))
 
     @classmethod
-    def deserialize_packet(cls, data):
-        return struct.unpack('BB', data)
+    def deserialize_packet(cls, data: bytes) -> Tuple[int, int]:
+        """
+        Deserializes a piece of data (a bytes object) into a tuple of two numbers.
+        The first number is the data carried by the packet, and the second is the checksum
+        computed by the board.
+
+        Returns:
+            bytes: The serialized packet.
+        """
+        return struct.unpack("BB", data)

--- a/mil_common/drivers/mil_pneumatic_actuator/mil_pneumatic_actuator/simulated_board.py
+++ b/mil_common/drivers/mil_pneumatic_actuator/mil_pneumatic_actuator/simulated_board.py
@@ -1,30 +1,35 @@
-#!/usr/bin/env python
-from mil_misc_tools.serial_tools import SimulatedSerial
-from constants import Constants
+#!/usr/bin/env python3
 import rospy
+from mil_misc_tools.serial_tools import SimulatedSerial
+
+from .constants import Constants
 
 
 class SimulatedPnuematicActuatorBoard(SimulatedSerial):
-    '''
+    """
     A simulation of the pneumatic actuator board's serial protocol
-    '''
+    """
+
     def __init__(self, *args, **kwargs):
         super(SimulatedPnuematicActuatorBoard, self).__init__()
 
-    def write(self, data):
+    def write(self, data: bytes):
+        """
+        Writes a series of bytes and completes the necessary actions.
+        """
         request = Constants.deserialize_packet(data)
         request = request[0]
         if request == Constants.PING_REQUEST:
-            rospy.loginfo('Ping received')
+            rospy.loginfo("Ping received")
             byte = Constants.PING_RESPONSE
         elif request > 0x20 and request < 0x30:
-            rospy.loginfo('Open port {}'.format(request - 0x20))
+            rospy.loginfo("Open port {}".format(request - 0x20))
             byte = Constants.OPEN_RESPONSE
         elif request > 0x30 and request < 0x40:
-            rospy.loginfo('Close port {}'.format(request - 0x30))
+            rospy.loginfo("Close port {}".format(request - 0x30))
             byte = Constants.CLOSE_RESPONSE
         else:
-            rospy.loginfo('Default')
+            rospy.loginfo("Default")
             byte = 0x00
         self.buffer += Constants.serialize_packet(byte)
         return len(data)

--- a/mil_common/drivers/mil_pneumatic_actuator/nodes/pneumatic_actuator_node
+++ b/mil_common/drivers/mil_pneumatic_actuator/nodes/pneumatic_actuator_node
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import rospy
 from serial import SerialException
 from mil_pneumatic_actuator import PnuematicActuatorDriver, PnuematicActuatorDriverError
@@ -9,12 +9,14 @@ import threading
 lock = threading.Lock()
 
 
-class Actuator(object):
-    '''
+class Actuator:
+    """
     Encapsulates the configuration for an actuator, which can contain up to 2 valves
-    and can be of 'set' or 'pulse type.
-    '''
-    def __init__(self, type_str, open_id, open_default, close_id, close_default, pulse_time):
+    and can be of 'set' or 'pulse' type.
+    """
+    def __init__(
+        self, type_str, open_id, open_default, close_id, close_default, pulse_time
+    ):
         self.pulse_time = pulse_time
         self.type = type_str
         self.open_id = open_id
@@ -26,33 +28,34 @@ class Actuator(object):
     def from_dict(cls, config):
         if type(config) == int:
             return cls.from_int(config)
-        type_str = config['type']
-        pulse_time = config['pulse_time'] if 'pulse_time' in config else None
-        open_id = config['ports']['open_port']['id']
-        open_default = config['ports']['open_port']['default']
-        if 'close_port' in config['ports']:
-            close_id = config['ports']['close_port']['id']
-            close_default = config['ports']['close_port']['default']
-            return cls(type_str, open_id, open_default, close_id, close_default, pulse_time)
+        type_str = config["type"]
+        pulse_time = config["pulse_time"] if "pulse_time" in config else None
+        open_id = config["ports"]["open_port"]["id"]
+        open_default = config["ports"]["open_port"]["default"]
+        if "close_port" in config["ports"]:
+            close_id = config["ports"]["close_port"]["id"]
+            close_default = config["ports"]["close_port"]["default"]
+            return cls(
+                type_str, open_id, open_default, close_id, close_default, pulse_time
+            )
         return cls(type_str, open_id, open_default, -1, 0, pulse_time)
 
     @classmethod
     def from_int(cls, valve_id):
-        return cls('set', valve_id, 0, -1, 0, 0.)
+        return cls("set", valve_id, 0, -1, 0, 0.0)
 
 
-class PnuematicActuatorNode():
-    '''
+class PnuematicActuatorNode:
+    """
     Allows high level ros code to interface with Daniel's pneumatics board.
-
-    TODO: Add a function to try and reconnect to the serial port if we lose connection.
-    TODO: publish info to /diagnostics
-    '''
+    """
+    # TODO: Add a function to try and reconnect to the serial port if we lose connection.
+    # TODO: publish info to /diagnostics
     def __init__(self):
         # Connect to board of serial or simulated serial
-        self.baud_rate = rospy.get_param('~baud_rate', 9600)
-        self.port = rospy.get_param('~port')
-        self.is_simulation = rospy.get_param('/is_simulation', False)
+        self.baud_rate = rospy.get_param("~baud_rate", 9600)
+        self.port = rospy.get_param("~port")
+        self.is_simulation = rospy.get_param("/is_simulation", False)
 
         self.connected = False
         while not self.connected:
@@ -61,7 +64,7 @@ class PnuematicActuatorNode():
                 rospy.sleep(1)
 
         # Parse actuator config from parameters. see example.launch for format
-        actuators = rospy.get_param('~actuators')
+        actuators = rospy.get_param("~actuators")
         self.actuators = {}
         for a in actuators:
             self.actuators[a] = Actuator.from_dict(actuators[a])
@@ -69,51 +72,57 @@ class PnuematicActuatorNode():
         # Reset all actuators to default
         self.reset()
 
-        rospy.Service('~actuate', SetValve, self.got_service_request)
-        rospy.Service('~reset', Trigger, self.reset)
+        rospy.Service("~actuate", SetValve, self.got_service_request)
+        rospy.Service("~reset", Trigger, self.reset)
 
         # Setup timer to ping every 5 second
         self.timer = rospy.Timer(rospy.Duration(3.0), self.reconnect_and_ping)
 
     def reset(self, *args):
-        '''
+        """
         Reset all valves to default state
-        '''
+        """
         for actuator in self.actuators.values():
             self.set_port(actuator.open_id, actuator.open_default)
             self.set_port(actuator.close_id, actuator.close_default)
-        rospy.loginfo('Valves set to default state')
-        return {'success': True}
+        rospy.loginfo("Valves set to default state")
+        return {"success": True}
 
     def set_raw_valve(self, srv):
-        '''
+        """
         Set a valve open/close by raw id
-        '''
-        rospy.loginfo('Setting valve {} to {}'.format(srv.actuator, 'open' if srv.opened else 'closed'))
+        """
+        rospy.loginfo(
+            "Setting valve {} to {}".format(
+                srv.actuator, "open" if srv.opened else "closed"
+            )
+        )
         self.set_port(int(srv.actuator), srv.opened)
-        return {'success': True}
+        return {"success": True}
 
     def set_port(self, port, state):
-        '''
+        """
         Open/Close a valve (by raw id), absorbing errors into logging
-        '''
+        """
         if port == -1:
             return False
         try:
             self.driver.set_port(port, state)
         except (PnuematicActuatorDriverError, SerialException) as e:
-            rospy.logerr('Error interfacing with actuator board: {}'.format(e))
+            rospy.logerr("Error interfacing with actuator board: {}".format(e))
             return False
         return True
 
     def reconnect_and_ping(self, *args):
-        '''
+        """
         Try to ping board, reconnecting if needed
-        '''
+        """
         # If board is disconnected, try to connect / reconnect
         if not self.connected:
             try:
-                self.driver = PnuematicActuatorDriver(self.port, baud=self.baud_rate, simulated=self.is_simulation)
+                self.driver = PnuematicActuatorDriver(
+                    self.port, baud=self.baud_rate, simulated=self.is_simulation
+                )
             except SerialException as e:
                 rospy.logwarn(e)
                 return
@@ -122,23 +131,23 @@ class PnuematicActuatorNode():
         try:
             self.driver.ping()
         except (PnuematicActuatorDriverError, SerialException) as e:
-            rospy.logwarn('Could not ping actuator board: {}'.format(e))
+            rospy.logwarn("Could not ping actuator board: {}".format(e))
             if self.connected:
-                rospy.logerr('Board not responding to pings. Disconnected.')
+                rospy.logerr("Board not responding to pings. Disconnected.")
                 self.connected = False
             return
 
         # If made it this far, you are not connected
         if not self.connected:
-            rospy.loginfo('Board connected!')
+            rospy.loginfo("Board connected!")
             self.connected = True
 
     def got_service_request(self, srv):
-        '''
+        """
         Close/Open/Pulse the requested actuator when a service request is recieved
-        '''
+        """
         if not self.connected:
-            return {'success': False, 'message': 'board not connected'}
+            return {"success": False, "message": "board not connected"}
         # See if requested actuator is just the raw ID
         try:
             int(srv.actuator)
@@ -148,12 +157,14 @@ class PnuematicActuatorNode():
 
         # Otherwise, make sure actuator was described in parameters
         if srv.actuator not in self.actuators:
-            return {'success': False, 'message': 'actuator not registered'}
+            return {"success": False, "message": "actuator not registered"}
         actuator = self.actuators[srv.actuator]
 
         # If actuator is pulse type, open it and setup timer to close after pulse time
-        if actuator.type == 'pulse':
-            rospy.loginfo('Pulsing {} for {}s'.format(srv.actuator, actuator.pulse_time))
+        if actuator.type == "pulse":
+            rospy.loginfo(
+                "Pulsing {} for {}s".format(srv.actuator, actuator.pulse_time)
+            )
             self.set_port(actuator.open_id, not actuator.open_default)
             self.set_port(actuator.close_id, not actuator.close_default)
 
@@ -164,16 +175,16 @@ class PnuematicActuatorNode():
             rospy.Timer(rospy.Duration(actuator.pulse_time), close, oneshot=True)
 
         # If actuator is set type, open/close as requested
-        elif actuator.type == 'set':
+        elif actuator.type == "set":
             if srv.opened:
-                rospy.loginfo('Opening {}'.format(srv.actuator))
+                rospy.loginfo("Opening {}".format(srv.actuator))
                 self.set_port(actuator.open_id, True)
                 self.set_port(actuator.close_id, False)
             else:
-                rospy.loginfo('Closing {}'.format(srv.actuator))
+                rospy.loginfo("Closing {}".format(srv.actuator))
                 self.set_port(actuator.open_id, False)
                 self.set_port(actuator.close_id, True)
-        return {'success': True}
+        return {"success": True}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR migrates the `mil_pneumatic_actuator` package to Python 3, and adds documentation on the package throughout the code and to the RST doc.