### PR TITLE
Migrate the `navigator_emergency_control` package to Python 3

### DIFF
--- a/NaviGator/utils/remote_control/navigator_emergency_control/nodes/navigator_emergency.py
+++ b/NaviGator/utils/remote_control/navigator_emergency_control/nodes/navigator_emergency.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-
+#!/usr/bin/env python3
 from remote_control_lib import RemoteControl
 import rospy
 from sensor_msgs.msg import Joy
@@ -12,11 +10,7 @@ __copyright__ = "Copyright 2016, MIL"
 __license__ = "MIT"
 
 
-rospy.init_node("emergency")
-
-
-class Joystick(object):
-
+class Joystick:
     def __init__(self):
         self.force_scale = rospy.get_param("/joystick_wrench/force_scale", 600)
         self.torque_scale = rospy.get_param("/joystick_wrench/torque_scale", 500)
@@ -27,11 +21,11 @@ class Joystick(object):
         self.active = False
         self.reset()
 
-    def reset(self):
-        '''
+    def reset(self) -> None:
+        """
         Used to reset the state of the controller. Sometimes when it
         disconnects then comes back online, the settings are all out of whack.
-        '''
+        """
         self.last_raise_kill = False
         self.last_clear_kill = False
         self.last_station_hold_state = False
@@ -61,10 +55,12 @@ class Joystick(object):
                     self.reset()
 
         else:
-            joy.header.stamp = rospy.Time.now()  # In the sim, stamps weren't working right
+            joy.header.stamp = (
+                rospy.Time.now()
+            )  # In the sim, stamps weren't working right
             self.last_joy = joy
 
-    def joy_recieved(self, joy):
+    def joy_recieved(self, joy: Joy) -> None:
         self.last_time = rospy.Time.now()
         self.check_for_timeout(joy)
 
@@ -79,7 +75,7 @@ class Joystick(object):
         thruster_deploy = bool(joy.buttons[5])
 
         if go_inactive and not self.last_go_inactive:
-            rospy.loginfo('Go inactive pressed. Going inactive')
+            rospy.loginfo("Go inactive pressed. Going inactive")
             self.reset()
             return
 
@@ -133,11 +129,11 @@ class Joystick(object):
         rotation = joy.axes[3] * self.torque_scale
         self.remote.publish_wrench(x, y, rotation, joy.header.stamp)
 
-    def die_check(self, event):
-        '''
+    def die_check(self, _: rospy.timer.TimerEvent) -> None:
+        """
         Publishes zeros after 2 seconds of no update
         in case node navigator_emergency_xbee dies
-        '''
+        """
         if self.active:
 
             # No new instructions after 2 seconds
@@ -148,6 +144,8 @@ class Joystick(object):
 
 
 if __name__ == "__main__":
+    rospy.init_node("emergency")
+
     emergency = Joystick()
     rospy.Timer(rospy.Duration(1), emergency.die_check, oneshot=False)
     rospy.spin()


### PR DESCRIPTION
This PR closes:
- #699

Typings were added throughout the only node in the package, but documentation may want to be expanded upon later. There is a `README.md` file in the package, and it may be desired to have this file merged into Alabaster.