### PR TITLE
Fixed node names in various launch scripts

### DIFF
--- a/NaviGator/mission_control/navigator_launch/launch/perception/passive_sonar.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/perception/passive_sonar.launch
@@ -8,6 +8,6 @@
   <node pkg="mil_passive_sonar" type="multilateration" name="multilateration">
     <param name="buffer_size" value="10" />
   </node>
-  <node pkg="mil_tools" type="vector_to_marker" name="hydrophones_visualization"
+  <node pkg="mil_tools" type="vector_to_marker.py" name="hydrophones_visualization"
         args="/hydrophones/direction /hydrophones/direction_marker --length 8" />
 </launch>

--- a/SubjuGator/command/sub8_launch/launch/subsystems/nav_box.launch
+++ b/SubjuGator/command/sub8_launch/launch/subsystems/nav_box.launch
@@ -49,7 +49,7 @@
       </rosparam>
     </node>
 
-    <node pkg="mil_tools" type="mag_to_marker" name="magnetometer_vis"
+    <node pkg="mil_tools" type="mag_to_marker.py" name="magnetometer_vis"
           args="/imu/mag /imu/marker -l3" />
   </group>
 

--- a/SubjuGator/command/sub8_launch/launch/subsystems/passive_sonar.launch
+++ b/SubjuGator/command/sub8_launch/launch/subsystems/passive_sonar.launch
@@ -13,7 +13,7 @@
   </group>
 
   <group if="$(eval environment == 'real')" ns="$(arg ns)">
-    <node pkg="mil_passive_sonar" type="run_sylphase_driver" name="run_sylphase_driver"
+    <node pkg="mil_passive_sonar" type="run_sylphase_driver.sh" name="run_sylphase_driver"
           args="$(arg port)"
           respawn="true"
           respawn_delay="5" />
@@ -21,9 +21,9 @@
 
   <group ns="$(arg ns)">
     <rosparam command="load" file="$(find sub8_launch)/config/$(arg config_file)" />
-    <node pkg="mil_passive_sonar" type="triggering" output="screen" name="triggering" respawn="true"/>
-    <node pkg="mil_passive_sonar" type="ping_locator" output="screen" name="ping_locator" respawn="true"/>
-    <node pkg="mil_tools" type="vector_to_marker" name="hydrophones_visualization"
+    <node pkg="mil_passive_sonar" type="triggering.py" output="screen" name="triggering" respawn="true"/>
+    <node pkg="mil_passive_sonar" type="ping_locator.py" output="screen" name="ping_locator" respawn="true"/>
+    <node pkg="mil_tools" type="vector_to_marker.py" name="hydrophones_visualization"
           args="$(arg ns)/direction $(arg ns)/direction_marker --length 4" />
   </group>
 </launch>


### PR DESCRIPTION
This PR fixes some launch scripts by updating the names of various nodes. Many nodes received a `.py` or `.sh` extension which broke some launch files - this PR should fix many of these cases for now.