### PR TITLE
Add documentation and typings to `txros`

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3518,6 +3518,20 @@ Publisher
 .. autoclass:: txros.Publisher
     :members:
 
+Exceptions
+^^^^^^^^^^
+.. attributetable:: txros.Error
+
+.. autoclass:: txros.Error
+    :members:
+
+Proxy
+^^^^^
+.. attributetable:: txros.Proxy
+
+.. autoclass:: txros.Proxy
+    :members:
+
 rviz
 ----
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3504,6 +3504,13 @@ ActionClient
 .. autoclass:: txros.ActionClient
     :members:
 
+NodeHandle
+^^^^^^^^^^
+.. attributetable:: txros.NodeHandle
+
+.. autoclass:: txros.NodeHandle
+    :members:
+
 rviz
 ----
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3460,9 +3460,9 @@ txros
 Goal
 ^^^^
 
-.. attributetable:: Goal
+.. attributetable:: txros.Goal
 
-.. autoclass:: Goal
+.. autoclass:: txros.Goal
     :members:
 
     .. attribute:: goal
@@ -3482,6 +3482,20 @@ Goal
         The string version of the goal's status.
 
         :rtype: :class:`str`
+
+GoalManager
+^^^^^^^^^^^
+.. attributetable:: txros.GoalManager
+
+.. autoclass:: txros.GoalManager
+    :members:
+
+SimpleActionServer
+^^^^^^^^^^^^^^^^^^
+.. attributetable:: txros.SimpleActionServer
+
+.. autoclass:: txros.SimpleActionServer
+    :members:
 
 rviz
 ----

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3525,11 +3525,23 @@ Exceptions
 .. autoclass:: txros.Error
     :members:
 
+.. attributetable:: txros.ServiceError
+
+.. autoclass:: txros.ServiceError
+    :members:
+
 Proxy
 ^^^^^
 .. attributetable:: txros.Proxy
 
 .. autoclass:: txros.Proxy
+    :members:
+
+ServiceClient
+^^^^^^^^^^^^^
+.. attributetable:: txros.ServiceClient
+
+.. autoclass:: txros.ServiceClient
     :members:
 
 rviz

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3497,6 +3497,13 @@ SimpleActionServer
 .. autoclass:: txros.SimpleActionServer
     :members:
 
+ActionClient
+^^^^^^^^^^^^
+.. attributetable:: txros.ActionClient
+
+.. autoclass:: txros.ActionClient
+    :members:
+
 rviz
 ----
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3632,6 +3632,20 @@ TransformListener
 .. autoclass:: txros.TransformListener
     :members:
 
+Event
+^^^^^
+.. attributetable:: txros.Event
+
+.. autoclass:: txros.Event
+    :members:
+
+Variable
+^^^^^^^^
+.. attributetable:: txros.Variable
+
+.. autoclass:: txros.Variable
+    :members:
+
 rviz
 ----
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3544,6 +3544,13 @@ ServiceClient
 .. autoclass:: txros.ServiceClient
     :members:
 
+Service
+^^^^^^^
+.. attributetable:: txros.Service
+
+.. autoclass:: txros.Service
+    :members:
+
 rviz
 ----
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3551,6 +3551,13 @@ Service
 .. autoclass:: txros.Service
     :members:
 
+Subscriber
+^^^^^^^^^^
+.. attributetable:: txros.Subscriber
+
+.. autoclass:: txros.Subscriber
+    :members:
+
 rviz
 ----
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3511,6 +3511,13 @@ NodeHandle
 .. autoclass:: txros.NodeHandle
     :members:
 
+Publisher
+^^^^^^^^^
+.. attributetable:: txros.Publisher
+
+.. autoclass:: txros.Publisher
+    :members:
+
 rviz
 ----
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -268,6 +268,54 @@ PoseWithCovariance
 
         :type: List[float]
 
+Transform
+~~~~~~~~~
+
+.. attributetable:: geometry_msgs.msg.Transform
+
+.. class:: geometry_msgs.msg.Transform
+
+    A ROS message type representing an object's transform.
+
+    .. attribute:: translation
+
+        The translation of the transform.
+
+        :type: ~geometry_msgs.msg.Vector3
+
+    .. attribute:: rotation
+
+        The rotation of the transform.
+
+        :type: ~geometry_msgs.msg.Quaternion
+
+TransformStamped
+~~~~~~~~~~~~~~~~
+
+.. attributetable:: geometry_msgs.msg.TransformStamped
+
+.. class:: geometry_msgs.msg.TransformStamped
+
+    A stamped ROS message type representing an object's transform.
+
+    .. attribute:: header
+
+        The header of the message.
+
+        :type: ~std_msgs.msg.Header
+
+    .. attribute:: child_frame_id
+
+        The ID of the child frame.
+
+        :type: str
+
+    .. attribute:: transform
+
+        The transform in the message.
+
+        :type: ~geometry_msgs.msg.Transform
+
 Accel
 ~~~~~
 
@@ -3529,6 +3577,11 @@ Exceptions
 
 .. autoclass:: txros.ServiceError
     :members:
+   
+.. attributetable:: txros.TooPastError
+
+.. autoclass:: txros.TooPastError
+    :members:
 
 Proxy
 ^^^^^
@@ -3556,6 +3609,27 @@ Subscriber
 .. attributetable:: txros.Subscriber
 
 .. autoclass:: txros.Subscriber
+    :members:
+
+Transform
+^^^^^^^^^^
+.. attributetable:: txros.Transform
+
+.. autoclass:: txros.Transform
+    :members:
+
+TransformBroadcaster
+^^^^^^^^^^^^^^^^^^^^
+.. attributetable:: txros.TransformBroadcaster
+
+.. autoclass:: txros.TransformBroadcaster
+    :members:
+
+TransformListener
+^^^^^^^^^^^^^^^^^
+.. attributetable:: txros.TransformListener
+
+.. autoclass:: txros.TransformListener
     :members:
 
 rviz


### PR DESCRIPTION
This PR adds typings and documentation to several classes and methods. Not all methods/classes were documented because the types of some were not clear, and some could not be well understood.