### PR TITLE
Replace all instances of `distutils.core` with `setuptools`

### DIFF
--- a/NaviGator/gnc/navigator_path_planner/setup.py
+++ b/NaviGator/gnc/navigator_path_planner/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # Fetch values from package.xml

--- a/NaviGator/gnc/navigator_thrust_mapper/setup.py
+++ b/NaviGator/gnc/navigator_thrust_mapper/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/NaviGator/hardware_drivers/navigator_kill_board/setup.py
+++ b/NaviGator/hardware_drivers/navigator_kill_board/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # Fetch values from package.xml

--- a/NaviGator/mission_control/navigator_alarm/setup.py
+++ b/NaviGator/mission_control/navigator_alarm/setup.py
@@ -1,7 +1,7 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/NaviGator/mission_control/navigator_missions/setup.py
+++ b/NaviGator/mission_control/navigator_missions/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/NaviGator/mission_systems/navigator_scan_the_code/setup.py
+++ b/NaviGator/mission_systems/navigator_scan_the_code/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/NaviGator/perception/navigator_vision/setup.py
+++ b/NaviGator/perception/navigator_vision/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 

--- a/NaviGator/test/navigator_test/setup.py
+++ b/NaviGator/test/navigator_test/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 

--- a/NaviGator/utils/navigator_gui/setup.py
+++ b/NaviGator/utils/navigator_gui/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # Fetch values from package.xml

--- a/NaviGator/utils/navigator_robotx_comms/setup.py
+++ b/NaviGator/utils/navigator_robotx_comms/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/NaviGator/utils/navigator_tools/setup.py
+++ b/NaviGator/utils/navigator_tools/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/NaviGator/utils/remote_control/navigator_keyboard_control/setup.py
+++ b/NaviGator/utils/remote_control/navigator_keyboard_control/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # Fetch values from package.xml

--- a/NaviGator/utils/voltage_gui/setup.py
+++ b/NaviGator/utils/voltage_gui/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(packages=["voltage_gui"], package_dir={"": "src"})

--- a/SubjuGator/command/sub8_alarm/setup.py
+++ b/SubjuGator/command/sub8_alarm/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/SubjuGator/command/sub8_missions/setup.py
+++ b/SubjuGator/command/sub8_missions/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/SubjuGator/drivers/sub8_actuator_board/setup.py
+++ b/SubjuGator/drivers/sub8_actuator_board/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # Fetch values from package.xml

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/setup.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # Fetch values from package.xml

--- a/SubjuGator/gnc/rise_6dof/setup.py
+++ b/SubjuGator/gnc/rise_6dof/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/SubjuGator/gnc/sub8_controller/setup.py
+++ b/SubjuGator/gnc/sub8_controller/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/SubjuGator/gnc/sub8_system_id/setup.py
+++ b/SubjuGator/gnc/sub8_system_id/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/SubjuGator/perception/sub8_perception/setup.py
+++ b/SubjuGator/perception/sub8_perception/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/SubjuGator/simulation/sub8_gazebo/setup.py
+++ b/SubjuGator/simulation/sub8_gazebo/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/SubjuGator/simulation/sub8_simulation/setup.py
+++ b/SubjuGator/simulation/sub8_simulation/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 

--- a/SubjuGator/utils/sub8_diagnostics/setup.py
+++ b/SubjuGator/utils/sub8_diagnostics/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/docker/base/system_install
+++ b/docker/base/system_install
@@ -88,7 +88,7 @@ sudo pip3 install --ignore-installed --upgrade pip \
     pyyaml
 
 # Documentation dependencies
-mil_system_install  python3-pip python-setuptools
+mil_system_install  python3-pip python3-setuptools
 
 # Install Python 3 ROS node dependencies
 sudo pip3 install -q \

--- a/mil_common/drivers/mil_passive_sonar/setup.py
+++ b/mil_common/drivers/mil_passive_sonar/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/mil_common/drivers/mil_pneumatic_actuator/setup.py
+++ b/mil_common/drivers/mil_pneumatic_actuator/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # Fetch values from package.xml

--- a/mil_common/drivers/mil_usb_to_can/setup.py
+++ b/mil_common/drivers/mil_usb_to_can/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # Fetch values from package.xml

--- a/mil_common/drivers/sabertooth2x12/setup.py
+++ b/mil_common/drivers/sabertooth2x12/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # Fetch values from package.xml

--- a/mil_common/gnc/mil_bounds/setup.py
+++ b/mil_common/gnc/mil_bounds/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 setup_args = generate_distutils_setup(

--- a/mil_common/gnc/rawgps_common/setup.py
+++ b/mil_common/gnc/rawgps_common/setup.py
@@ -1,6 +1,6 @@
 #  ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 setup_args = generate_distutils_setup(

--- a/mil_common/mil_missions/setup.py
+++ b/mil_common/mil_missions/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # Fetch values from package.xml

--- a/mil_common/perception/mil_mlp/setup.py
+++ b/mil_common/perception/mil_mlp/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/mil_common/perception/mil_vision/mil_vision_tools/objects_tracker.py
+++ b/mil_common/perception/mil_vision/mil_vision_tools/objects_tracker.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 import abc
 import numpy as np
 import rospy

--- a/mil_common/perception/mil_vision/setup.py
+++ b/mil_common/perception/mil_vision/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/mil_common/ros_alarms/setup.py
+++ b/mil_common/ros_alarms/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/mil_common/utils/mil_poi/setup.py
+++ b/mil_common/utils/mil_poi/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/mil_common/utils/mil_tools/setup.py
+++ b/mil_common/utils/mil_tools/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml


### PR DESCRIPTION
One step needed in the migration is the replacement of the `setup` function from the `distutils.core` package with the `setup` function from the `setuptools` package.