### PR TITLE
Issue DeprecationWarning for imports from `navigator_scan_the_code` package

### DIFF
--- a/NaviGator/mission_systems/navigator_scan_the_code/navigator_scan_the_code/__init__.py
+++ b/NaviGator/mission_systems/navigator_scan_the_code/navigator_scan_the_code/__init__.py
@@ -1,3 +1,5 @@
-import scan_the_code_mission
+import warnings
+warnings.warn("This package has been deprecated.", DeprecationWarning, stacklevel = 2)
+# from . import scan_the_code_mission
 
-from scan_the_code_mission import *
+# from .scan_the_code_mission import *


### PR DESCRIPTION
This PR operates on the following issue:

- #733

The issue is not closed because the package has not been moved to the deprecated folder. That will occur sometime in the fall semester, likely.