### PR TITLE
Fix broken GitHub Workflow using wrong payload object type

### DIFF
--- a/.github/workflows/issue_non_member.yaml
+++ b/.github/workflows/issue_non_member.yaml
@@ -15,7 +15,7 @@ jobs:
           github-token: ${{secrets.INVESTIGATOR_BOT_TOKEN}}
           script: |
             const closeableStates = ["none", "read"];
-            const creator = context.payload.comment.user.login;
+            const creator = context.payload.issue.user.login;
             const response = await github.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
This PR fixes an issue with one of the GitHub Actions workflows dedicated to handling issues created by users who are not members of MIL.

There was a typo where the `payload` object was referenced, and that has now been fixed.