### PR TITLE
Ensure GitHub Pages concurrency group depends on PR number

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 concurrency:
-  group: "pages"
+  group: pages-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
lol oops

Forgot to include the PR number with the concurrency group for GH Pages deployment builds.