### PR TITLE
CI pushes main docs site contents on pushes to master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -619,6 +619,10 @@ jobs:
 
       - name: Rename docs folder
         run: |
+          ls
+          cd $GITHUB_WORKSPACE
+          ls
+          ls build
           mv build/docs-ci-html-${{ github.sha }} build/docs
 
       # We need to install rsync for GitHub Pages deploy action

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -602,7 +602,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - docs
-    # if: github.ref == 'refs/heads/master' -- testing
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -594,6 +594,45 @@ jobs:
       - name: Publish docs artifact
         uses: actions/upload-artifact@v3
         with:
-          name: >
-            docs-ci-html-${{ github.sha }}
+          name: docs-ci-html-${{ github.sha }}
           path: ${{ github.workspace }}/.mil/docs/html
+
+  deploy-docs:
+    name: Deploy docs from master
+    runs-on: ubuntu-latest
+    needs:
+      - docs
+    # if: github.ref == 'refs/heads/master' -- testing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Make folders
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/build
+
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: docs-ci-html-${{ github.sha }}
+          path: ${{ github.workspace }}/build
+
+      - name: Rename docs folder
+        run: |
+          mv docs-ci-html-${{ github.sha }} docs
+
+      # We need to install rsync for GitHub Pages deploy action
+      - name: Install rsync
+        run: |
+          sudo apt-get upgrade && sudo apt-get update && sudo apt-get install -y rsync
+
+      # Publish the artifact to the GitHub Pages branch
+      - name: Push docs to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          token: ${{ secrets.INVESTIGATOR_BOT_TOKEN }}
+          branch: main
+          repository-name: uf-mil/uf-mil.github.io
+          folder: ${{ github.workspace }}/build/docs
+          target-folder: docs
+          commit-message: Updating docs to ${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -609,21 +609,13 @@ jobs:
 
       - name: Make folders
         run: |
-          mkdir -p $GITHUB_WORKSPACE/build
+          mkdir -p $GITHUB_WORKSPACE/build/docs
 
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
           name: docs-ci-html-${{ github.sha }}
-          path: ${{ github.workspace }}/build
-
-      - name: Rename docs folder
-        run: |
-          ls
-          cd $GITHUB_WORKSPACE
-          ls
-          ls build
-          mv build/docs-ci-html-${{ github.sha }} build/docs
+          path: ${{ github.workspace }}/build/docs
 
       # We need to install rsync for GitHub Pages deploy action
       - name: Install rsync

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -619,7 +619,7 @@ jobs:
 
       - name: Rename docs folder
         run: |
-          mv docs-ci-html-${{ github.sha }} docs
+          mv build/docs-ci-html-${{ github.sha }} build/docs
 
       # We need to install rsync for GitHub Pages deploy action
       - name: Install rsync


### PR DESCRIPTION
This PR adds a step in the CI, where if a user pushed a commit to `master`, the CI will deploy the docs build from that commit to GitHub Pages. Before this, the main `uf-mil.github.io/docs` site was not being updated automatically.