### PR TITLE
Add ci config to pre-commit config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -390,6 +390,12 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache: "pip"
+      # The alex hook seems to fail quite a bit in CI now, let's try installing
+      # node to see if that will help.
+      - name: Setup up Node (for alex hook)
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Initialize pre-commit for use
         run: |
           python --version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,12 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache: "pip"
+      # The alex hook seems to fail quite a bit in CI now, let's try installing
+      # node to see if that will help.
+      - name: Setup up Node (for alex hook)
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Install pre-commit hooks
         run: |
           python --version
@@ -390,12 +396,6 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache: "pip"
-      # The alex hook seems to fail quite a bit in CI now, let's try installing
-      # node to see if that will help.
-      - name: Setup up Node (for alex hook)
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
       - name: Initialize pre-commit for use
         run: |
           python --version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,12 +94,6 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache: "pip"
-      # The alex hook seems to fail quite a bit in CI now, let's try installing
-      # node to see if that will help.
-      - name: Setup up Node (for alex hook)
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
       - name: Install pre-commit hooks
         run: |
           python --version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ ci:
   autofix_prs: false
   autoupdate_commit_msg: 'Update pre-commit hooks to latest versions'
   autoupdate_schedule: monthly
-  skip: [alex]  # Requests access to DNS, not allowed for pre-commit CI
 
 repos:
   - repo: https://github.com/pycqa/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
     hooks:
       - id: alex
         name: alex
-        types: [markdown, rst]
+        types: [markdown]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,11 @@ exclude: ^deprecated/
 default_language_version:
   python: python3.8
 
+ci:
+  autofix_prs: false
+  autoupdate_commit_msg: 'Update pre-commit hooks to latest versions'
+  autoupdate_schedule: monthly
+
 repos:
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
     hooks:
       - id: alex
         name: alex
-        types: [markdown]
+        types: [markdown, rst]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ ci:
   autofix_prs: false
   autoupdate_commit_msg: 'Update pre-commit hooks to latest versions'
   autoupdate_schedule: monthly
+  skip: [alex]  # Requests access to DNS, not allowed for pre-commit CI
 
 repos:
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
This PR adds configuration for the `pre-commit` CI bot that helps to update linter versions automatically. This makes it easier to keep our linter specs up to date.