### PR TITLE
Remove unused debug print statement, add missing sub singleton class

### DIFF
--- a/SubjuGator/command/sub8_missions/sub8_missions/__init__.py
+++ b/SubjuGator/command/sub8_missions/sub8_missions/__init__.py
@@ -14,6 +14,7 @@ from .start_gate import StartGate
 from .start_gate_2022 import StartGate2022
 from .start_gate_guess import StartGateGuess
 from .strip import Strip
+from .sub_singleton import SubjuGator
 from .surface import Surface
 from .torpedos_test import TorpedosTest
 from .vampire_slayer import VampireSlayer

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/simulation.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/simulation.py
@@ -137,7 +137,6 @@ class ThrusterAndKillBoardSimulation(SimulatedCANDevice):
         :class:`ThrustPacket`, and :class:`HeartbeatMessage` types.
         """
         assert can_id == THRUST_SEND_ID or can_id == KILL_SEND_ID
-        print(data[0], data)
         if KillMessage.IDENTIFIER == data[0]:
             packet = KillMessage.from_bytes(data)
             assert packet.is_command


### PR DESCRIPTION
This PR adds two items:
* Adds the missing `SubjuGator` class into the list of exported classes from the `sub8_missions` module
* Removes the debug print statement in the sub8 drivers folder