### PR TITLE
Remove the alex node-based linter from pre-commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -414,7 +414,6 @@ jobs:
           pre-commit run trailing-whitespace --all-files --show-diff-on-failure
           pre-commit run mixed-line-ending --all-files --show-diff-on-failure
           pre-commit run check-json --all-files --show-diff-on-failure
-          pre-commit run alex --all-files --show-diff-on-failure
           pre-commit run check-executables-have-shebangs --all-files --show-diff-on-failure
 
   catkin_test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,12 +56,6 @@ repos:
       - id: prettier-launch-xml
       - id: prettier-package-xml
       - id: sort-package-xml
-  - repo: https://github.com/christopher-haueter/pre-commit-alex
-    rev: v0.1.2
-    hooks:
-      - id: alex
-        name: alex
-        types: [markdown]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:


### PR DESCRIPTION
This PR removes the `alex` linter from the list of `pre-commit` hooks used in our repo. Because this linter is based on `node`, installing it can be quite the hassle...

I don't think that it's worth the time investment needed.