### PR TITLE
Correct heartbeat message client and server to meet 2022 requirements

### DIFF
--- a/NaviGator/mission_control/navigator_launch/launch/master.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/master.launch
@@ -18,7 +18,10 @@
     <include file="$(find navigator_launch)/launch/hardware.launch">
        <arg name="simulation" value="$(arg simulation)" />
     </include>
-    <include unless="$(arg simulation)" file="$(find navigator_launch)/launch/robotx_comms.launch"/>
+
+    <include file="$(find navigator_launch)/launch/robotx_comms.launch">
+      <arg name="simulation" value="$(arg simulation)"/>
+    </include>
 
     <!-- Run computer vision / sonar perception nodes -->
     <include file="$(find navigator_launch)/launch/perception.launch">

--- a/NaviGator/mission_control/navigator_launch/launch/robotx_comms.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/robotx_comms.launch
@@ -1,10 +1,30 @@
 <launch>
+
+    <arg name="td_ip" default="robot.server" />
+    <arg name="td_port" default="9000" />
+    <arg name="team_id" default="GATR" />
+    <arg name="simulation" default="False"/>
+
     <!-- start robotx_comms node -->
-    <node name="navigator_robotx_comms" pkg="navigator_robotx_comms" type="robotx_comms_client.py" >
-        <param name="~td_ip" value="robot.server" />
-        <param name="~td_port" value="9000" />
-        <param name="~team_id" value="GATR" />
-        <!-- sets data to protocol sample data - KEEP FALSE-->
-        <param name="~use_test_data" value="false" />
-    </node>
+
+    <group unless="$(arg simulation)">
+        <node name="navigator_robotx_comms" pkg="navigator_robotx_comms" type="robotx_comms_client.py" >
+            <param name="~td_ip" value="$(arg td_ip)" />
+            <param name="~td_port" value="$(arg td_port)" />
+            <param name="~team_id" value="$(arg team_id)" />
+            <!-- sets data to protocol sample data - KEEP FALSE-->
+            <param name="~use_test_data" value="false" />
+        </node>
+    </group>
+
+    <group if="$(arg simulation)">
+        <node name="navigator_robotx_comms" pkg="navigator_robotx_comms" type="robotx_comms_client.py" >
+            <param name="~td_ip" value="127.0.0.1" />
+            <param name="~td_port" value="1337" />
+            <param name="~team_id" value="GATOR" />
+            <!-- sets data to protocol sample data - KEEP FALSE-->
+            <param name="~use_test_data" value="false" />
+        </node>
+    </group>
+
 </launch>

--- a/NaviGator/mission_control/navigator_missions/navigator_missions/entrance_gate.py
+++ b/NaviGator/mission_control/navigator_missions/navigator_missions/entrance_gate.py
@@ -5,7 +5,7 @@ import numpy as np
 import tf2_ros
 from mil_misc_tools import ThrowingArgumentParser
 from mil_tools import rosmsg_to_numpy
-from navigator_msgs.srv import MessageExtranceExitGate, MessageExtranceExitGateRequest
+from navigator_msgs.srv import MessageEntranceExitGate, MessageEntranceExitGateRequest
 from twisted.internet import defer
 from txros import util
 
@@ -94,7 +94,7 @@ class EntranceGate(Navigator):
         cls.parser = parser
 
         cls.net_service_call = cls.nh.get_service_client(
-            "/entrance_exit_gate_message", MessageExtranceExitGate
+            "/entrance_exit_gate_message", MessageEntranceExitGate
         )
 
     @util.cancellableInlineCallbacks
@@ -122,7 +122,7 @@ class EntranceGate(Navigator):
 
         self.send_feedback("Gate identified as " + str(self.pinger_gate + 1))
         if args.exit:
-            msg = MessageExtranceExitGateRequest()
+            msg = MessageEntranceExitGateRequest()
             if self.net_entrance_results is not None:
                 msg.entrance_gate = self.net_entrance_results
             else:

--- a/NaviGator/utils/navigator_msgs/CMakeLists.txt
+++ b/NaviGator/utils/navigator_msgs/CMakeLists.txt
@@ -53,9 +53,13 @@ add_service_files(
   FindPinger.srv
   SetFrequency.srv
   GetDockBays.srv
-  MessageDetectDeliver.srv
-  MessageExtranceExitGate.srv
-  MessageIdentifySymbolsDock.srv
+  MessageDetectDock.srv
+  MessageEntranceExitGate.srv
+  MessageFindFling.srv
+  MessageFollowPath.srv
+  MessageReactReport.srv
+  MessageUAVReplenishment.srv
+  MessageUAVSearchReport.srv
   TwoClosestCones.srv
 )
 

--- a/NaviGator/utils/navigator_msgs/srv/MessageDetectDeliver.srv
+++ b/NaviGator/utils/navigator_msgs/srv/MessageDetectDeliver.srv
@@ -1,4 +1,0 @@
-string shape_color  # R=red, B=blue, G=green
-string shape  # CRUCI=cruciform, TRIAN=triangle, CIRCL=circle
----
-string message

--- a/NaviGator/utils/navigator_msgs/srv/MessageDetectDock.srv
+++ b/NaviGator/utils/navigator_msgs/srv/MessageDetectDock.srv
@@ -1,0 +1,4 @@
+string color  # color of docking bay R, G, B
+int8 ams_status  # 1=docking, 2=complete
+---
+string message

--- a/NaviGator/utils/navigator_msgs/srv/MessageEntranceExitGate.srv
+++ b/NaviGator/utils/navigator_msgs/srv/MessageEntranceExitGate.srv
@@ -1,0 +1,4 @@
+int8 entrance_gate  # gate 1, 2, 3
+int8 exit_gate  # gate 1, 2, 3
+---
+string message

--- a/NaviGator/utils/navigator_msgs/srv/MessageExtranceExitGate.srv
+++ b/NaviGator/utils/navigator_msgs/srv/MessageExtranceExitGate.srv
@@ -1,6 +1,0 @@
-int8 entrance_gate  # gate 1, 2, 3
-int8 exit_gate  # gate 1, 2, 3
-bool light_buoy_active  # true if active, false if inactive
-string light_pattern  # R=red, B=blue, G=green, empty if not active
----
-string message

--- a/NaviGator/utils/navigator_msgs/srv/MessageFindFling.srv
+++ b/NaviGator/utils/navigator_msgs/srv/MessageFindFling.srv
@@ -1,0 +1,4 @@
+string color  # color of shape R, G, B
+int8 ams_status  # 1=scanning, 2=flinging
+---
+string message

--- a/NaviGator/utils/navigator_msgs/srv/MessageFollowPath.srv
+++ b/NaviGator/utils/navigator_msgs/srv/MessageFollowPath.srv
@@ -1,0 +1,3 @@
+int8 finished # 1=in progress 2=completed
+---
+string message

--- a/NaviGator/utils/navigator_msgs/srv/MessageIdentifySymbolsDock.srv
+++ b/NaviGator/utils/navigator_msgs/srv/MessageIdentifySymbolsDock.srv
@@ -1,4 +1,0 @@
-string shape_color  # R=red, B=blue, G=green
-string shape  # CRUCI=cruciform, TRIAN=triangle, CIRCL=circle
----
-string message

--- a/NaviGator/utils/navigator_msgs/srv/MessageReactReport.srv
+++ b/NaviGator/utils/navigator_msgs/srv/MessageReactReport.srv
@@ -1,0 +1,3 @@
+string[] animal_array # list of animals (P,C,T), up to three animals (Platypus, Turtle, Croc)
+---
+string message

--- a/NaviGator/utils/navigator_msgs/srv/MessageUAVReplenishment.srv
+++ b/NaviGator/utils/navigator_msgs/srv/MessageUAVReplenishment.srv
@@ -1,0 +1,4 @@
+int8 uav_status # 1=stowed, 2=deployed, 3=faulted
+int8 item_status # 0=not picked up, 1=picked up, 2=delivered
+---
+string message

--- a/NaviGator/utils/navigator_msgs/srv/MessageUAVSearchReport.srv
+++ b/NaviGator/utils/navigator_msgs/srv/MessageUAVSearchReport.srv
@@ -1,0 +1,13 @@
+string object1
+float64 object1_latitude
+string object1_n_s
+float64 object1_longitude
+string object1_e_w
+string object2
+float64 object2_latitude
+string object2_n_s
+float64 object2_longitude
+string object2_e_w
+int8 uav_status # 1=manual, 2=autonomous, 3=faulted
+---
+string message

--- a/NaviGator/utils/navigator_robotx_comms/CMakeLists.txt
+++ b/NaviGator/utils/navigator_robotx_comms/CMakeLists.txt
@@ -16,6 +16,11 @@ find_package(catkin REQUIRED COMPONENTS
   mil_tools
 )
 
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest(test/robotx_comms.test)
+endif()
+
 catkin_python_setup()
 
 catkin_package()

--- a/NaviGator/utils/navigator_robotx_comms/navigator_robotx_comms/__init__.py
+++ b/NaviGator/utils/navigator_robotx_comms/navigator_robotx_comms/__init__.py
@@ -1,7 +1,11 @@
 from .navigator_robotx_comms import (
-    RobotXDetectDeliverMessage,
+    RobotXDetectDockMessage,
     RobotXEntranceExitGateMessage,
+    RobotXFindFlingMessage,
+    RobotXFollowPathMessage,
     RobotXHeartbeatMessage,
-    RobotXIdentifySymbolsDockMessage,
+    RobotXReactReportMessage,
     RobotXScanCodeMessage,
+    RobotXUAVReplenishmentMessage,
+    RobotXUAVSearchReportMessage,
 )

--- a/NaviGator/utils/navigator_robotx_comms/test/server.py
+++ b/NaviGator/utils/navigator_robotx_comms/test/server.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import rospy
+from robotx_comms_server import RobotXServer
+
+if __name__ == "__main__":
+    rospy.init_node("comms_server")
+
+    tcp_ip = rospy.get_param("/navigator_robotx_comms/td_ip")
+    tcp_port = rospy.get_param("/navigator_robotx_comms/td_port")
+
+    server = RobotXServer(tcp_ip, tcp_port)
+
+    server.connect()
+    while not rospy.is_shutdown():
+        rx_data = None
+        while rx_data is None:
+            rx_data = server.receive_message()
+        rospy.logwarn(rx_data)
+
+    rospy.spin()

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Welcome to the repository for the Machine Intelligence Lab at the University of Florida, a robotics lab in Gainesville, Florida. Our lab has built [several robotic systems](https://mil.ufl.edu/projects/) since its inception several decades ago. Our current projects include:
 
-* **SubjuGator:** An autonomous, underwater submarine-like vehicle. Three-time champion of the AUSVI/ONR underwater competition. ([Website](https://subjugator.org))
+* **SubjuGator:** An autonomous, underwater submarine-like vehicle. Three-time champion of the AUVSI/ONR underwater competition. ([Website](https://subjugator.org))
 * **NaviGator:** An autonomous surface vehicle (ASV) which has competed in several maritime competitions. Won the 2016 Maritime RobotX Challenge, and received fourth in the 2018 Maritime RobotX Challenge. ([Website](https://subjugator.org))
 * **Virtual RobotX:** An new extension of the NaviGator project supporting virtual robotics.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Machine Intelligence Lab
 
 Welcome to the documentation site for the Machine Intelligence Lab at the University of Florida, a robotics lab in Gainesville, Florida. Our lab has built `several robotic systems <https://mil.ufl.edu/projects/>`_ since its inception several decades ago. Our current projects include:
 
-* **SubjuGator:** An autonomous, underwater submarine-like vehicle. Three-time champion of the AUSVI/ONR underwater competition. (`Website <https://subjugator.org>`_)
+* **SubjuGator:** An autonomous, underwater submarine-like vehicle. Three-time champion of the AUVSI/ONR underwater competition. (`Website <https://subjugator.org>`_)
 * **NaviGator:** An autonomous surface vehicle (ASV) which has competed in several maritime competitions. Won the 2016 Maritime RobotX Challenge, and received fourth in the 2018 Maritime RobotX Challenge. (`Website <https://subjugator.org>`_)
 * **Virtual RobotX:** An new extension of the NaviGator project supporting virtual robotics.
 

--- a/docs/navigator/reference.rst
+++ b/docs/navigator/reference.rst
@@ -38,17 +38,17 @@ MessageDetectDeliver
 
         :type: str
 
-MessageExtranceExitGate
+MessageEntranceExitGate
 ^^^^^^^^^^^^^^^^^^^^^^^
-.. attributetable:: navigator_msgs.srv.MessageExtranceExitGateRequest
+.. attributetable:: navigator_msgs.srv.MessageEntranceExitGateRequest
 
-.. class:: navigator_msgs.srv.MessageExtranceExitGateRequest
+.. class:: navigator_msgs.srv.MessageEntranceExitGateRequest
 
-   The request class for the ``navigator_msgs/MessageExtranceExitGate`` service.
+   The request class for the ``navigator_msgs/MessageEntranceExitGate`` service.
 
-   .. attribute:: Extrance_gate
+   .. attribute:: Entrance_gate
 
-        The Extrance gate relevant to the task.
+        The Entrance gate relevant to the task.
 
         :type: int
 
@@ -72,11 +72,11 @@ MessageExtranceExitGate
 
         :type: str
 
-.. attributetable:: navigator_msgs.srv.MessageExtranceExitGateResponse
+.. attributetable:: navigator_msgs.srv.MessageEntranceExitGateResponse
 
-.. class:: navigator_msgs.srv.MessageExtranceExitGateResponse
+.. class:: navigator_msgs.srv.MessageEntranceExitGateResponse
 
-   The response class for the ``navigator_msgs/MessageExtranceExitGate`` service.
+   The response class for the ``navigator_msgs/MessageEntranceExitGate`` service.
 
    .. attribute:: message
 
@@ -155,9 +155,9 @@ ScanTheCodeMission
 
         :type: List[str]
 
-AUSVI Communication
+AUVSI Communication
 -------------------
-Below outline classes that are used to allow NaviGator to communicate with AUSVI-specific
+Below outline classes that are used to allow NaviGator to communicate with AUVSI-specific
 platforms.
 
 RobotXEntranceExitGateMessage


### PR DESCRIPTION
More corrections are needed to simulation environment before we can fully see data from simulation within heartbeat message. However, for now, I corrected the heartbeat client code, along with the code for receiving and sending to td station the entrance/exit gate messages, follow the path messages, wildlife encounter messages, scan the code messages, detect and dock messages, find and fling messages, uav replenishment messages, and the uav search and report messages.

I wrote unittests for each one of these. You can run it with ```rostest navigator_robotx_comms robotx_comms.test```.

The heartbeat message can now be seen from within the simulation environment. The idea is that the simulation environment will be run in the future with ```roslaunch navigator_launch master.launch``` (which contains an arg for simulation or not). If you launch this and then launch ```rosrun navigator_robotx_comms server.py```, you will see any messages that we would send to the td station in competition. All the information is not quite there because there are a few issues that need to be handled outside of this heartbeat issue.

Basically, all these messages we have to send to the td station, I have it set up such that we will have call a ros service and the robotx_comms node will handle gathering, parsing, and sending the information to the td station. We just need to set up the rest of the code to send the proper information to those ros services.