### PR TITLE
Corrected urdf issue with NaviGator

### DIFF
--- a/NaviGator/mission_control/navigator_launch/launch/gnc/tf.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/gnc/tf.launch
@@ -14,7 +14,7 @@
     <node pkg="nodelet" type="nodelet" name="transform_odometry" args="standalone odometry_utils/transform_odometry">
         <rosparam>
             frame_id: /enu
-            child_frame_id: /base_link
+            child_frame_id: wamv/base_link
         </rosparam>
         <remap from="orig_odom" to="ins_odom"/>
     </node>

--- a/NaviGator/mission_control/navigator_launch/launch/hardware.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/hardware.launch
@@ -1,7 +1,7 @@
 <launch>
   <arg name="simulation" default="False" />
   <include unless="$(arg simulation)" file="$(find navigator_launch)/launch/hardware/motor_controller.launch"/>
-  <include file="$(find navigator_launch)/launch/hardware/grinch_motor.launch" />
+  <include unless="$(arg simulation)" file="$(find navigator_launch)/launch/hardware/grinch_motor.launch" />
   <include unless="$(arg simulation)" file="$(find navigator_launch)/launch/hardware/gps.launch" />
   <include file="$(find navigator_launch)/launch/hardware/cameras.launch">
     <arg name="simulation" value="$(arg simulation)"/>

--- a/NaviGator/mission_control/navigator_launch/launch/hardware/gps.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/hardware/gps.launch
@@ -1,7 +1,7 @@
 <launch>
     <node name="sylphase_ros_driver" pkg="navigator_tools" type="sylphase_ros_driver">
         <param name="port" value="1234" />
-        <param name="child_frame_id" value="ins" />
+        <param name="child_frame_id" value="wamv/ins" />
         <param name="force_z_to_zero" value="False" />
         <remap from="/odom" to="/ins_odom" />
     </node>

--- a/NaviGator/simulation/navigator_gazebo/launch/goose.launch
+++ b/NaviGator/simulation/navigator_gazebo/launch/goose.launch
@@ -1,18 +1,30 @@
 <?xml version="1.0"?>
 <!-- Run gazebo with navigator in a RobotX course -->
 <launch>
-  <arg name="gui" default="true" />
-
-  <!-- URDF Model of Navigator -->
+  <arg name="gui" default="False" />
+  <arg name="use_mil_world" default="False"/>
+  <arg name="world" default="example_course" />
+  <arg name="extra_gazebo_args" default=""/>
   <arg name="urdf" default="$(find navigator_gazebo)/urdf/navigator.urdf" />
-  <param name="robot_description" textfile="$(arg urdf)"/>
 
-  <include file="$(find gazebo_ros)/launch/empty_world.launch">
-    <arg name="world_name" value="$(find vrx_gazebo)/worlds/example_course.world" />
-    <arg name="gui" value="$(arg gui)" />
-    <arg name="verbose" value="true" />
+  <include if="$(eval use_mil_world == False)" file="$(find vrx_gazebo)/launch/vrx.launch">
+      <arg name="gui" value="$(arg gui)"/>
+      <arg name="urdf" value="$(arg urdf)"/>
+      <arg name="world" value="$(find vrx_gazebo)/worlds/$(arg world).world" />
+      <arg name="extra_gazebo_args" default="--verbose"/>
+      <arg name="vrx_sensors_enabled" default="false"/>
+      <!--<arg name="x" default="0" />
+      <arg name="y" default="0" />
+      <arg name="z" default="0.1" />-->
   </include>
-
-  <!-- Spawn model in Gazebo -->
-  <include file="$(find navigator_gazebo)/launch/spawn_navigator.launch" />
+  <include if="$(eval use_mil_world == True)" file="$(find vrx_gazebo)/launch/vrx.launch">
+      <arg name="gui" value="$(arg gui)"/>
+      <arg name="urdf" value="$(arg urdf)"/>
+      <arg name="world" value="$(find navigator_gazebo)/worlds/$(arg world).world" />
+      <arg name="extra_gazebo_args" default="--verbose"/>
+      <arg name="vrx_sensors_enabled" default="false"/>
+      <arg name="x" default="0" />
+      <arg name="y" default="0" />
+      <arg name="z" default="0.1" />
+  </include>
 </launch>

--- a/NaviGator/simulation/navigator_gazebo/urdf/navigator.urdf.xacro
+++ b/NaviGator/simulation/navigator_gazebo/urdf/navigator.urdf.xacro
@@ -6,45 +6,39 @@
   <!-- Fixed frames for sensors -->
   <xacro:include filename="$(find navigator_gazebo)/urdf/fixed_link.xacro"/>
   <xacro:include filename="$(find navigator_gazebo)/urdf/sylphase.xacro"/>
-  <xacro:fixed_link name="measurement" xyz="1.2319 0 1.2" rpy="0 0 0"/>
+  <xacro:fixed_link name="${namespace}/measurement" parent="${namespace}/base_link" xyz="1.2319 0 1.2" rpy="0 0 0"/>
 
-  <xacro:sylphase name="ins" xyz="0.579628 0.136525 1.392278" rpy="0 0 0"/>
-  <xacro:fixed_link name="velodyne" parent="measurement" xyz="-0.277622 0 0.648208" rpy="0 0 0"/>
-  <xacro:fixed_link name="sick" parent="measurement" xyz="0.5334 -0.0254 -0.6858" rpy="0 0 0"/>
+  <xacro:sylphase name="${namespace}/ins" parent='${namespace}/base_link' xyz="0.579628 0.136525 1.392278" rpy="0 0 0"/>
+  <xacro:fixed_link name="${namespace}/velodyne" parent="${namespace}/measurement" xyz="-0.277622 0 0.648208" rpy="0 0 0"/>
+  <xacro:fixed_link name="${namespace}/sick" parent="${namespace}/measurement" xyz="0.5334 -0.0254 -0.6858" rpy="0 0 0"/>
 
-  <xacro:fixed_link name="pinger_direction" parent="velodyne" xyz="0.8382 0 -2.0828" rpy="0 0 0"/>
+  <xacro:fixed_link name="${namespace}/pinger_direction" parent="${namespace}/velodyne" xyz="0.8382 0 -2.0828" rpy="0 0 0"/>
 
   <!-- Camera frames with gazebo simulation plugins -->
   <xacro:include filename="$(find navigator_gazebo)/urdf/camera.xacro"/>
-  <xacro:navigator_camera name="front_left_cam" parent="velodyne" namespace="/camera/front/left" xyz="0.294 0.1 -0.45" rpy="0 0.258 0"/>
-  <xacro:navigator_camera name="front_right_cam" parent="velodyne" namespace="/camera/front/right" xyz="0.294 -0.099 -0.45" rpy="0 0.258 0"/>
-  <xacro:navigator_camera name="starboard_cam" parent="measurement" namespace="/camera/starboard" xyz="-0.4191 -0.6985 0.2159" rpy="0 0 -1.570796"/>
+  <xacro:navigator_camera name="${namespace}/front_left_cam" parent="${namespace}/velodyne" namespace="${namespace}/camera/front/left" xyz="0.294 0.1 -0.45" rpy="0 0.258 0"/>
+  <xacro:navigator_camera name="${namespace}/front_right_cam" parent="${namespace}/velodyne" namespace="${namespace}/camera/front/right" xyz="0.294 -0.099 -0.45" rpy="0 0.258 0"/>
+  <xacro:navigator_camera name="${namespace}/starboard_cam" parent="${namespace}/measurement" namespace="${namespace}/camera/starboard" xyz="-0.4191 -0.6985 0.2159" rpy="0 0 -1.570796"/>
 
-  <xacro:fixed_link name="shooter" parent="starboard_cam" xyz="0 0 0.2" rpy="0 0 0"/>
+  <xacro:fixed_link name="${namespace}/shooter" parent="${namespace}/starboard_cam" xyz="0 0 0.2" rpy="0 0 0"/>
 
   <!-- Add 4 thrusters -->
   <xacro:include filename="$(find navigator_gazebo)/urdf/thruster.xacro"/>
-  <xacro:navigator_thruster name="BL" x="-1.9304" y="1.016" yaw="0.785398"/>
-  <xacro:navigator_thruster name="BR" x="-1.9304" y="-1.016" yaw="-0.785398"/>
-  <xacro:navigator_thruster name="FL" x="1.5748" y="0.6096" yaw="-0.785398"/>
-  <xacro:navigator_thruster name="FR" x="1.5748" y="-0.6096" yaw="0.785398"/>
+  <xacro:navigator_thruster name="${namespace}/BL" parent="${namespace}/base_link" x="-1.9304" y="1.016" yaw="0.785398"/>
+  <xacro:navigator_thruster name="${namespace}/BR" parent="${namespace}/base_link" x="-1.9304" y="-1.016" yaw="-0.785398"/>
+  <xacro:navigator_thruster name="${namespace}/FL" parent="${namespace}/base_link" x="1.5748" y="0.6096" yaw="-0.785398"/>
+  <xacro:navigator_thruster name="${namespace}/FR" parent="${namespace}/base_link" x="1.5748" y="-0.6096" yaw="0.785398"/>
 
   <!-- Plugin to imitate roboteq motor driver for thrusters -->
   <gazebo>
     <plugin name="thrust_plugin" filename="libnavigator_thrusters.so">
-      <thruster>BL</thruster>
-      <thruster>BR</thruster>
-      <thruster>FL</thruster>
-      <thruster>FR</thruster>
-    </plugin>
-    <plugin name="pinger_heading_ground_truth" filename="libmil_model_heading.so">
-      <topic>/hydrophones/direction</topic>
-      <model>robotx_pinger</model>
-      <offset>0.102 -.635 -0.324 0 0 0</offset>
-      <frame>hydrophones</frame>
+      <thruster>${namespace}/BL</thruster>
+      <thruster>${namespace}/BR</thruster>
+      <thruster>${namespace}/FL</thruster>
+      <thruster>${namespace}/FR</thruster>
     </plugin>
   </gazebo>
-  <xacro:fixed_link name="hydrophones" parent="base_link" xyz="0.102 -.635 -0.324" rpy="0 0 0"/>
+  <xacro:fixed_link name="${namespace}/hydrophones" parent="${namespace}/base_link" xyz="0.102 -.635 -0.324" rpy="0 0 0"/>
 
   <!-- Attach hydrodynamics plugin -->
   <xacro:include filename="$(find wamv_gazebo)/urdf/macros.xacro"/>

--- a/NaviGator/simulation/navigator_gazebo/urdf/sylphase.xacro
+++ b/NaviGator/simulation/navigator_gazebo/urdf/sylphase.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="sylphase" params="name='ins'
+  <xacro:macro name="sylphase" params="name='ins' parent='base_link'
                         xyz:='0 0 0' rpy:='0 0 0'">
     <xacro:include filename="$(find navigator_gazebo)/urdf/fixed_link_persistent.xacro"/>
     <link name="${name}"/>
@@ -9,7 +9,7 @@
       <sensor name="${name}_gps" type="gps"/>
     </gazebo>
     <joint name="${name}_to_base_link" type="fixed">
-      <parent link="base_link"/>
+      <parent link="${parent}"/>
       <child link="${name}"/>
       <origin xyz="${xyz}" rpy="${rpy}"/>
     </joint>

--- a/NaviGator/simulation/navigator_gazebo/urdf/thruster.xacro
+++ b/NaviGator/simulation/navigator_gazebo/urdf/thruster.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="wam-v-two-engines">
   <!-- Macro for inserting an engine with its propeller. -->
-  <xacro:macro name="navigator_thruster" params="name x y yaw">
+  <xacro:macro name="navigator_thruster" params="name parent x y yaw">
     <!-- Location of propeller from origin of engine -->
     <xacro:property name="prop_x_offset" value="-0.278156"/>
 
@@ -14,7 +14,7 @@
     <link name="${name}_engine_link">
       <visual>
         <geometry>
-          <mesh filename="package://wamv_description/mesh/engine.dae"/>
+          <mesh filename="package://wamv_description/models/engine/mesh/engine.dae"/>
         </geometry>
       </visual>
       <collision name="${name}_engine_vertical_axis_collision">
@@ -38,7 +38,7 @@
     <link name="${name}_propeller_link">
       <visual>
         <geometry>
-          <mesh filename="package://wamv_description/mesh/propeller.dae"/>
+          <mesh filename="package://wamv_description/models/propeller/mesh/propeller.dae"/>
         </geometry>
       </visual>
       <collision name="${name}_propeller_collision">
@@ -55,7 +55,7 @@
 
     <joint name="${name}_chasis_engine_joint" type="fixed">
       <origin xyz="${x_engine} ${y_engine} 0.318237" rpy="0.0 0.0 ${yaw}"/>
-      <parent link="base_link"/>
+      <parent link="${parent}"/>
       <child link="${name}_engine_link"/>
     </joint>
 

--- a/mil_common/drivers/mil_pneumatic_actuator/mil_pneumatic_actuator/simulated_board.py
+++ b/mil_common/drivers/mil_pneumatic_actuator/mil_pneumatic_actuator/simulated_board.py
@@ -20,7 +20,7 @@ class SimulatedPnuematicActuatorBoard(SimulatedSerial):
         request = Constants.deserialize_packet(data)
         request = request[0]
         if request == Constants.PING_REQUEST:
-            rospy.loginfo("Ping received")
+            # rospy.loginfo("Ping received")
             byte = Constants.PING_RESPONSE
         elif request > 0x20 and request < 0x30:
             rospy.loginfo(f"Open port {request - 0x20}")


### PR DESCRIPTION
Corrected urdf issue with NaviGator. You can now run ```roslaunch navigator_launch simulation.launch```, and you will see that no fatal errors occur. Moreover, if you run ```amonitor kill``` to unkill, you can publish a wrench to the wrench_cmd topic to see the boat move. More work needs to be done to make the simulation more complete. Coming soon.