### PR TITLE
Added __str__ and __repr__ methods to SimulatedSerial

### DIFF
--- a/mil_common/utils/mil_tools/mil_misc_tools/serial_tools.py
+++ b/mil_common/utils/mil_tools/mil_misc_tools/serial_tools.py
@@ -98,6 +98,11 @@ class SimulatedSerial(NoopSerial):
     def __init__(self):
         self.buffer = b""
 
+    def __str__(self) -> str:
+        return f"<SimulatedSerial at 0x{id(self):0x}, buffer={self.buffer}>"
+
+    __repr__ = __str__
+
     @property
     def in_waiting(self) -> int:
         """

--- a/mil_common/utils/mil_tools/mil_misc_tools/serial_tools.py
+++ b/mil_common/utils/mil_tools/mil_misc_tools/serial_tools.py
@@ -89,6 +89,18 @@ class SimulatedSerial(NoopSerial):
     Note: :class:`NoopSerial` and :class:`SimulatedSerial` are generic and are
     candidates for mil_common.
 
+    .. container:: operations
+
+        .. describe:: str(x)
+
+            Pretty prints the ``SimulatedSerial`` object, its address, and the start
+            of its buffer.
+
+        .. describe:: repr(x)
+
+            Pretty prints the ``SimulatedSerial`` object, its address, and the start
+            of its buffer. Equivalent to ``str(x)``.
+
     Attributes:
         buffer (bytes): A buffer of bytes waiting to be read from the device.
     """
@@ -99,7 +111,7 @@ class SimulatedSerial(NoopSerial):
         self.buffer = b""
 
     def __str__(self) -> str:
-        return f"<SimulatedSerial at 0x{id(self):0x}, buffer={self.buffer}>"
+        return f"<SimulatedSerial at 0x{id(self):0x}, buffer={self.buffer[:10]}>"
 
     __repr__ = __str__
 


### PR DESCRIPTION
This branch was meant to fix issue  https://github.com/uf-mil/mil/issues/761 '`mil_tools.SimulatedSerial `needs custom `__repr__` and `__str__` methods' 
