### PR TITLE
ImageSubscriber and ImagePublisher now properly use NodeHandle

### DIFF
--- a/docs/reference/vision.rst
+++ b/docs/reference/vision.rst
@@ -242,3 +242,17 @@ PcdSubPubAlgorithm
 .. cppattributetable:: mil_vision::PcdSubPubAlgorithm
 
 .. doxygenclass:: mil_vision::PcdSubPubAlgorithm
+
+
+ImagePublisher
+^^^^^^^^^^^^^^^^^^
+.. cppattributetable:: ImagePublisher
+
+.. doxygenclass:: ImagePublisher
+
+
+ImageSubscriber
+^^^^^^^^^^^^^^^^^^
+.. cppattributetable:: ImageSubscriber
+
+.. doxygenclass:: ImageSubscriber

--- a/mil_common/utils/mil_tools/include/mil_tools/image_publisher.hpp
+++ b/mil_common/utils/mil_tools/include/mil_tools/image_publisher.hpp
@@ -13,6 +13,5 @@ public:
 private:
   std::string encoding_;
   image_transport::Publisher pub_;
-  ros::NodeHandle nh_;
   image_transport::ImageTransport it_;
 };

--- a/mil_common/utils/mil_tools/include/mil_tools/image_publisher.hpp
+++ b/mil_common/utils/mil_tools/include/mil_tools/image_publisher.hpp
@@ -4,10 +4,27 @@
 
 #include <opencv2/highgui/highgui.hpp>
 
+/**
+ * Abstraction for publishing images to without the necessary boiler plate.
+ * All that's needed to publish an image is a cv::Mat.
+ */
 class ImagePublisher
 {
 public:
-  ImagePublisher(const std::string& topic, const std::string& encoding = "bgr8", int queue_size = 1);
+  /**
+   * Creates an ImagePublisher in the namespace of nh.
+   * @param nh NodeHandle to have node in the correct namespace.
+   * @param topic Camera topic to publish images to.
+   * @param encoding Type of image encoding
+   * @param queue_size Size of the queue for the publisher.
+   */
+  ImagePublisher(const ros::NodeHandle& nh, const std::string& topic, const std::string& encoding = "bgr8",
+                 int queue_size = 1);
+
+  /**
+   * Publishes an OpenCV image.
+   * @param image_arg OpenCV image to publish.
+   */
   void publish(cv::Mat& image_arg);
 
 private:

--- a/mil_common/utils/mil_tools/include/mil_tools/image_subscriber.hpp
+++ b/mil_common/utils/mil_tools/include/mil_tools/image_subscriber.hpp
@@ -14,36 +14,71 @@
 #include <opencv2/opencv.hpp>
 #include <type_traits>
 
+/**
+ * Abstraction for subscribing to image outputs and their info.
+ * This returns a copy or reference of the image depending on what you specify in the constructor.
+ * The camera info contains valuable information such as the camera matrix and will exit gracefully if not found.
+ */
 class ImageSubscriber
 {
 public:
+  /**
+   * Create an ImageSubscriber using a class member function as the function callback.
+   * @param nh NodeHandle for the node that is subscribing to a camera topic.
+   * @param topic Contains the camera topic to subscribe to.
+   * @param func Function pointer to class member callback function.
+   * @param object Pointer to object that function belongs to.
+   * @param use_copy Whether to use a copy or reference of the converted image. If unsure use copy.
+   * @param encoding Type of encoding for camera topic.
+   * @param queue_size Queue size to use for subscriber.
+   */
   template <typename T>
-  ImageSubscriber(const ros::NodeHandle& nh_, const std::string& topic, void (T::*func)(cv::Mat&), T* a,
-                  const std::string& encoding = "bgr8", int queue_size = 1)
-    : encoding_(encoding), queue_size_(queue_size), it_(nh_)
+  ImageSubscriber(const ros::NodeHandle& nh, const std::string& topic, void (T::*func)(cv::Mat&), T* object,
+                  bool use_copy = true, const std::string& encoding = "bgr8", int queue_size = 1)
+    : encoding_(encoding), queue_size_(queue_size), it_(nh)
   {
-    image_subscriber_ = it_.subscribe(topic, queue_size, &ImageSubscriber::imageCallback, this);
-    function_ = std::bind(func, a, std::placeholders::_1);
+    if (use_copy)
+    {
+      image_subscriber_ = it_.subscribe(topic, queue_size, &ImageSubscriber::imageCallbackCopy, this);
+    }
+    else
+    {
+      image_subscriber_ = it_.subscribe(topic, queue_size, &ImageSubscriber::imageCallbackReference, this);
+    }
+    function_ = std::bind(func, object, std::placeholders::_1);
     camera_info_sub_ = nh_.subscribe(getInfoTopic(topic), queue_size, &ImageSubscriber::infoCallback, this);
   }
 
-  ImageSubscriber(const ros::NodeHandle& nh_, const std::string& topic, void (*func)(cv::Mat&),
+  /**
+   * Create an ImageSubscriber using a normal function as the function callback.
+   * @param nh NodeHandle for the node that is subscribing to a camera topic.
+   * @param topic Contains the camera topic to subscribe to.
+   * @param func Function pointer to callback function.
+   * @param use_copy Whether to use a copy or reference of the converted image. If unsure use copy.
+   * @param encoding Type of encoding for camera topic.
+   * @param queue_size Queue size to use for subscriber.
+   */
+  ImageSubscriber(const ros::NodeHandle& nh, const std::string& topic, void (*func)(cv::Mat&), bool use_copy = true,
                   const std::string& encoding = "bgr8", int queue_size = 1)
-    : encoding_(encoding), queue_size_(queue_size), it_(nh_)
+    : encoding_(encoding), queue_size_(queue_size), it_(nh)
   {
-    image_subscriber_ = it_.subscribe(topic, queue_size, &ImageSubscriber::imageCallback, this);
+    if (use_copy)
+    {
+      image_subscriber_ = it_.subscribe(topic, queue_size, &ImageSubscriber::imageCallbackCopy, this);
+    }
+    else
+    {
+      image_subscriber_ = it_.subscribe(topic, queue_size, &ImageSubscriber::imageCallbackReference, this);
+    }
     function_ = func;
     camera_info_sub_ = nh_.subscribe(getInfoTopic(topic), queue_size, &ImageSubscriber::infoCallback, this);
   }
 
-  std::string getInfoTopic(const std::string& input)
-  {
-    int location = input.rfind('/');
-    if (location == input.length() - 1)
-      location = input.rfind('/', input.length() - 2);
-    return input.substr(0, location - 1) + "/camera_info";
-  }
-
+  /**
+   * Safely returns the camera info if it is found. Waits for timeout seconds to receive the camera info.
+   * @param timeout Time in seconds to wait for camera info to be received.
+   * @return optional value to return data if available otherwise nothing if not.
+   */
   boost::optional<sensor_msgs::CameraInfo> waitForCameraInfo(unsigned int timeout = 10)
   {
     ROS_WARN("Blocking -- waiting at most %d seconds for camera info.", timeout);
@@ -66,6 +101,12 @@ public:
     return boost::none;
   }
 
+  /**
+   * Waits for camera info to be received and fills in the given PinholeCameraModel with the data from it.
+   * @param pinhole_camera PineholeCameraModel to store the resulting camera model in.
+   * @param timeout Time in seconds to wait for camera info to be received.
+   * @return true if data is received, false otherwise.
+   */
   bool waitForCameraModel(image_geometry::PinholeCameraModel& pinhole_camera, unsigned int timeout = 10)
   {
     auto msg = waitForCameraInfo(timeout);
@@ -75,13 +116,21 @@ public:
     return true;
   }
 
+  /**
+   * Function callback for camera info.
+   * @param info Camera info message from ROS.
+   */
   void infoCallback(const sensor_msgs::CameraInfo& info)
   {
     camera_info_sub_.shutdown();
     camera_info_.emplace(info);
   }
 
-  void imageCallback(const sensor_msgs::ImageConstPtr& image)
+  /**
+   * Function callback for the image copy.
+   * @param image Image message from ROS.
+   */
+  void imageCallbackCopy(const sensor_msgs::ImageConstPtr& image)
   {
     try
     {
@@ -94,12 +143,46 @@ public:
     }
   }
 
+  /**
+   * Function callback for the image reference.
+   * @param image Image message from ROS.
+   */
+  void imageCallbackReference(const sensor_msgs::ImageConstPtr& image)
+  {
+    try
+    {
+      last_image_time_ = image.header.stamp;
+      function_(cv_bridge::toCvShare(image, encoding_)->image);
+    }
+    catch (cv_bridge::Exception& e)
+    {
+      ROS_ERROR("Could not convert from '%s' to '%s'.", image->encoding, encoding_);
+    }
+  }
+
+  /**
+   * Returns the timestamp for the last image.
+   * @return optional value containing the time the last image was received.
+   */
   boost::optional<std_msgs::Time> getLastImageTime()
   {
     return camera_info_;
   }
 
 private:
+  /**
+   * Parses the inputted topic to get the camera_info topic assuming standard pattern is followed.
+   * @param input Camera topic
+   * @return camera info topic
+   */
+  std::string getInfoTopic(const std::string& input)
+  {
+    int location = input.rfind('/');
+    if (location == input.length() - 1)
+      location = input.rfind('/', input.length() - 2);
+    return input.substr(0, location - 1) + "/camera_info";
+  }
+
   std::string encoding_;
   int queue_size_;
 

--- a/mil_common/utils/mil_tools/include/mil_tools/image_subscriber.hpp
+++ b/mil_common/utils/mil_tools/include/mil_tools/image_subscriber.hpp
@@ -18,8 +18,8 @@ class ImageSubscriber
 {
 public:
   template <typename T>
-  ImageSubscriber(const std::string& topic, void (T::*func)(cv::Mat&), T* a, const std::string& encoding = "bgr8",
-                  int queue_size = 1)
+  ImageSubscriber(const ros::NodeHandle& nh_, const std::string& topic, void (T::*func)(cv::Mat&), T* a,
+                  const std::string& encoding = "bgr8", int queue_size = 1)
     : encoding_(encoding), queue_size_(queue_size), it_(nh_)
   {
     image_subscriber_ = it_.subscribe(topic, queue_size, &ImageSubscriber::imageCallback, this);
@@ -27,8 +27,8 @@ public:
     camera_info_sub_ = nh_.subscribe(getInfoTopic(topic), queue_size, &ImageSubscriber::infoCallback, this);
   }
 
-  ImageSubscriber(const std::string& topic, void (*func)(cv::Mat&), const std::string& encoding = "bgr8",
-                  int queue_size = 1)
+  ImageSubscriber(const ros::NodeHandle& nh_, const std::string& topic, void (*func)(cv::Mat&),
+                  const std::string& encoding = "bgr8", int queue_size = 1)
     : encoding_(encoding), queue_size_(queue_size), it_(nh_)
   {
     image_subscriber_ = it_.subscribe(topic, queue_size, &ImageSubscriber::imageCallback, this);
@@ -105,8 +105,7 @@ private:
 
   std::function<void(cv::Mat&)> function_;
 
-  ros::NodeHandle nh_;
-  image_transport::ImageTransport it_(nh_);
+  image_transport::ImageTransport it_;
   image_transport::Subscriber image_subscriber_;
 
   ros::Subscriber camera_info_sub_;

--- a/mil_common/utils/mil_tools/src/mil_tools/image_publisher.cpp
+++ b/mil_common/utils/mil_tools/src/mil_tools/image_publisher.cpp
@@ -1,8 +1,8 @@
 #include <mil_tools/image_publisher.hpp>
 
-ImagePublisher::ImagePublisher(const ros::NodeHandle& nh_, const std::string& topic, const std::string& encoding,
+ImagePublisher::ImagePublisher(const ros::NodeHandle& nh, const std::string& topic, const std::string& encoding,
                                int queue_size)
-  : it_(nh_)
+  : it_(nh)
 {
   this->encoding_ = encoding;
   pub_ = it_.advertise(topic, queue_size);

--- a/mil_common/utils/mil_tools/src/mil_tools/image_publisher.cpp
+++ b/mil_common/utils/mil_tools/src/mil_tools/image_publisher.cpp
@@ -1,6 +1,8 @@
 #include <mil_tools/image_publisher.hpp>
 
-ImagePublisher::ImagePublisher(const std::string& topic, const std::string& encoding, int queue_size) : it_(nh_)
+ImagePublisher::ImagePublisher(const ros::NodeHandle& nh_, const std::string& topic, const std::string& encoding,
+                               int queue_size)
+  : it_(nh_)
 {
   this->encoding_ = encoding;
   pub_ = it_.advertise(topic, queue_size);


### PR DESCRIPTION
Before each ImageSubscriber and ImagePublisher instances would have their own NodeHandle instance which is not how it's supposed to be done.