### PR TITLE
Update POI server

### DIFF
--- a/NaviGator/navigator.rviz
+++ b/NaviGator/navigator.rviz
@@ -484,6 +484,15 @@ Visualization Manager:
       Show Visual Aids: false
       Update Topic: /pcodar_objects/update
       Value: true
+    - Class: rviz/InteractiveMarkers
+      Enable Transparency: true
+      Enabled: true
+      Name: POI Server
+      Show Axes: false
+      Show Descriptions: true
+      Show Visual Aids: false
+      Update Topic: /points_of_interest/update
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/docs/reference/poi.rst
+++ b/docs/reference/poi.rst
@@ -1,9 +1,44 @@
 :mod:`mil_poi` - POI Handling
 -----------------------------
 
+.. automodule:: mil_poi
+
+Using with Rviz
+^^^^^^^^^^^^^^^
+To view and interactive with interactive marker POIs in Rviz, you will need to enable
+the "Interactive Markers" panel in Rviz. You will then need to set the update topic
+to be equal to the update topic published by the interactive marker server published
+by the POI server. This topic name will likely end in ``/update``.
+
+All POIs are represented as spheres in the interactive marker server; you can move
+these spheres around to change their location. Note that points are currently
+fixed to the x and y axes, meaning that you can not have floating or submerged points.
+
+Configuration Files
+^^^^^^^^^^^^^^^^^^^
+When the POI server is launched, it is provided with several ROS parameters to
+describe how the server should function. This includes POIs that are spawned by
+default upon server initialization.
+
+The default format of the POI configuration file is the following format:
+
+.. code-block:: yaml
+
+    ---
+    global_frame: enu # Name of the frame to derive POI locations from
+    initial_pois: # List of POIs that are spawned by default
+      start_gate: [0, 0, 0] # Name (key) and location (value) of specific POIs
+
 POIServer
 ^^^^^^^^^
 .. attributetable:: mil_poi.POIServer
 
 .. autoclass:: mil_poi.POIServer
+    :members:
+
+TxPOIClient
+^^^^^^^^^^^
+.. attributetable:: mil_poi.TxPOIClient
+
+.. autoclass:: mil_poi.TxPOIClient
     :members:

--- a/mil_common/utils/mil_poi/mil_poi/__init__.py
+++ b/mil_common/utils/mil_poi/mil_poi/__init__.py
@@ -1,2 +1,41 @@
+"""
+The MIL POI system is used to keep track of relevant points of interest across
+a landscape. This can be used to give a robotic system a headstart in determining
+the final target of a mission; for example, a robotic system could be instructed
+to head to a specific POI before looking around more closely to find the actual object
+it needs to interact with.
+
+.. container:: services
+
+    .. describe:: /poi_server/add
+
+        :class:`mil_poi.srv.AddPOIRequest` → :class:`mil_poi.srv.AddPOIResponse`
+
+        Add a POI object into the POI server listing.
+
+    .. describe:: /poi_server/delete
+
+        :class:`mil_poi.srv.DeletePOIRequest` → :class:`mil_poi.srv.DeletePOIResponse`
+
+        Deletes a POI with the given name, and returns whether the deletion was successful.
+
+    .. describe:: /poi_server/move
+
+        :class:`mil_poi.srv.MovePOIRequest` → :class:`mil_poi.srv.MovePOIResponse`
+
+        Moves a POI with the given name to the given position, and returns whether
+        the move was successful.
+
+.. container:: topics
+
+    .. describe:: /points_of_interest/update
+
+        :class:`visualization_msgs.msg.InteractiveMarkerUpdate`
+
+        Sends updates about changes to interactive markers. When attempting to view
+        interactive markers in Rviz, the ``update_topic`` parameter of the Interactive
+        Markers panel needs to be set to this topic.
+"""
+
 from .server import POIServer
 from .tx_interface import TxPOIClient

--- a/mil_common/utils/mil_poi/mil_poi/server.py
+++ b/mil_common/utils/mil_poi/mil_poi/server.py
@@ -294,6 +294,9 @@ class POIServer:
             if poi.name == name:
                 pose = Pose()
                 pose.orientation.w = 1.0
+                pose.orientation.x = 0.0
+                pose.orientation.y = 1.0
+                pose.orientation.z = 0.0
                 pose.position = position
                 if not self.interactive_marker_server.setPose(name, pose):
                     return False
@@ -342,6 +345,9 @@ class POIServer:
         text_marker = Marker()
         text_marker.type = Marker.TEXT_VIEW_FACING
         text_marker.pose.orientation.w = 1.0
+        text_marker.pose.orientation.x = 0.0
+        text_marker.pose.orientation.y = 1.0
+        text_marker.pose.orientation.z = 0.0
         text_marker.pose.position.x = 1.5
         text_marker.text = poi.name
         text_marker.scale.z = 1.0
@@ -353,6 +359,9 @@ class POIServer:
         int_marker = InteractiveMarker()
         int_marker.header.frame_id = self.global_frame
         int_marker.pose.orientation.w = 1.0
+        int_marker.pose.orientation.x = 0.0
+        int_marker.pose.orientation.y = 1.0
+        int_marker.pose.orientation.z = 0.0
         int_marker.pose.position = poi.position
         int_marker.scale = 1
 
@@ -360,7 +369,7 @@ class POIServer:
 
         # insert a box
         control = InteractiveMarkerControl()
-        control.interaction_mode = InteractiveMarkerControl.MOVE_3D
+        control.interaction_mode = InteractiveMarkerControl.MOVE_PLANE
         control.always_visible = True
         control.markers.append(point_marker)
         control.markers.append(text_marker)


### PR DESCRIPTION
## Description
This PR adds the following items:
* Restrict POI points to x and y axes (no floating or submerged POIs)
* Document topics and services related to POIs
* Document POI configuration file format
* Refresh POI client class for new documentation format
* Add POI server visualization to default NaviGator rviz config


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->



## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closed #XXX" to close the issue when the PR is merged. -->

* None

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
1. `roslaunch navigator_launch simulation.launch --screen`
2. `nviz`
3. Observe that you are able to move POI points around.
4. Optionally, update the configuration file and re-launch the simulation to observe new default POIs.


## About This PR
<!-- BELOW: Have you checked the following? -->

- [x] I have updated documentation related to this change so that future members are aware of the changes I've made.
