### PR TITLE
Add more reliability/testing to `txros` publishers and subscribers

### DIFF
--- a/docs/reference/txros/api.rst
+++ b/docs/reference/txros/api.rst
@@ -7,6 +7,7 @@ Exception Hierarchy
 
     - :exc:`~txros.TxrosException`
         - :exc:`~txros.NotSetup`
+        - :exc:`~txros.AlreadySetup`
         - :exc:`~txros.XMLRPCException`
         - :exc:`~txros.ROSMasterError`
         - :exc:`~txros.ROSMasterFailure`
@@ -23,6 +24,11 @@ Exceptions
 .. attributetable:: txros.NotSetup
 
 .. autoclass:: txros.NotSetup
+    :members:
+
+.. attributetable:: txros.AlreadySetup
+
+.. autoclass:: txros.AlreadySetup
     :members:
 
 .. attributetable:: txros.XMLRPCException

--- a/docs/reference/txros/errors.rst
+++ b/docs/reference/txros/errors.rst
@@ -29,3 +29,20 @@ modern approach to this behavior includes using `Dynamic Reconfigure <https://wi
 Dynamic Reconfigure is more efficient than using the parameter subscriber feature
 previously mentioned, as dynamic reconfigure uses callbacks to indicate new changes,
 while nodes use a consistent polling feature to get updates on parameters.
+
+Subscribing to high-rate publishers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some publishers publish messages at very fast rates, which can add reliability
+and speed to a robotic system. However, txros may not be able to keep up with the
+high rate of incoming messages if the client code is constructed in particular
+ways.
+
+To ensure that the subscriber is able to read all incoming messages, ensure the following:
+
+1. Supply a callback to the subscriber that receives all incoming messages; do
+   not depend on using :meth:`txros.Subscriber.get_next_message`. The latter method
+   will cause messages to never be read if a callback is not supplied.
+2. When attempting to read all messages published by a publisher over a specific
+   period, use :meth:`txros.Subscriber.recently_read` to determine if more messages
+   still need to be read before the subscriber can be closed.

--- a/docs/reference/txros/errors.rst
+++ b/docs/reference/txros/errors.rst
@@ -1,5 +1,5 @@
-Common Errors
-^^^^^^^^^^^^^
+Errors and Known Issues
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Handling :class:`aiohttp.ClientConnectionError`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -16,3 +16,16 @@ Check the following things:
 If these appear correct, try restarting ROS (either by restarting `roscore` or `roslaunch`).
 It may be the case that a node stopped incorrectly or a service was improperly started,
 in which case ROS may believe a resource exists when it actually does not.
+
+Subscribing to parameter updates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using `rospy`, individual nodes can "subscribe" to particular parameters to receive
+updates on when these parameters are updated. This allows the nodes to quickly respond
+to changes made in the parameter server.
+
+However, this behavior has not been implemented in txros. This is because a more
+modern approach to this behavior includes using `Dynamic Reconfigure <https://wiki.ros.org/dynamic_reconfigure>`_.
+Dynamic Reconfigure is more efficient than using the parameter subscriber feature
+previously mentioned, as dynamic reconfigure uses callbacks to indicate new changes,
+while nodes use a consistent polling feature to get updates on parameters.


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
This PR adds the following to `txros`:
* `pre-commit` for easier developer interaction
* Support for multiple subscriptions/publications to the same topic on the same node handle
* Better explanation of handling high-rate publishers
* Testing high-rate subscribers/publishers
* Testing multiple subscriptions to the same topic using the same `txros.NodeHandle`
* Support for ensuring all messages from a short-lived publisher are read using `txros.Subscriber.recently_read`
* String representation of `txros.ServiceClient`, `txros.Service`, `txros.Publisher`, `txros.Subscriber`
* `txros.AlreadySetup` exception to indicate resource has already been `setup()`
* Raising `TypeError` for incorrect types provided to parameter methods for `txros.NodeHandle`


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->
Not relevant


## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closed #XXX" to close the issue when the PR is merged. -->

* None

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
Run `rostest txros txros.test` and observe that all tests pass, or view the CI logs to ensure that all tests successfully pass.


## About This PR
<!-- BELOW: Have you checked the following? --->

- [x] I have updated documentation related to this change so that future members are aware of the changes I've made.
