### PR TITLE
Added ability to give thrusters separate mechanical reductions

### DIFF
--- a/NaviGator/gnc/navigator_thrust_mapper/navigator_thrust_mapper/thruster_map.py
+++ b/NaviGator/gnc/navigator_thrust_mapper/navigator_thrust_mapper/thruster_map.py
@@ -156,7 +156,7 @@ class ThrusterMap:
         positions = []
         angles = []
         limit = -1
-        ratio = np.array([1.0,1.0,1.0,1.0])
+        ratio = np.array([1.0, 1.0, 1.0, 1.0])
         for i, transmission in enumerate(urdf.transmissions):
             find = transmission.name.find(transmission_suffix)
             if find != -1 and find + len(transmission_suffix) == len(transmission.name):
@@ -179,7 +179,7 @@ class ThrusterMap:
                     raise Exception(
                         "Thruster mapper does not allow negative mechanical reduction."
                     )
-                
+
                 ratio[i] = t_ratio
 
                 joint = None

--- a/NaviGator/gnc/navigator_thrust_mapper/navigator_thrust_mapper/thruster_map.py
+++ b/NaviGator/gnc/navigator_thrust_mapper/navigator_thrust_mapper/thruster_map.py
@@ -40,7 +40,7 @@ vrx_force_to_command = np.vectorize(vrx_force_to_command_scalar)
 
 def generate_linear_force_to_command(ratio):
     def force_to_command(force):
-        return force * ratio
+        return np.multiply(force, ratio)
 
     return force_to_command
 
@@ -156,8 +156,8 @@ class ThrusterMap:
         positions = []
         angles = []
         limit = -1
-        ratio = -1
-        for transmission in urdf.transmissions:
+        ratio = np.array([1.0,1.0,1.0,1.0])
+        for i, transmission in enumerate(urdf.transmissions):
             find = transmission.name.find(transmission_suffix)
             if find != -1 and find + len(transmission_suffix) == len(transmission.name):
                 if len(transmission.joints) != 1:
@@ -172,14 +172,16 @@ class ThrusterMap:
                             transmission.name
                         )
                     )
+
                 t_ratio = transmission.actuators[0].mechanicalReduction
-                if ratio != -1 and ratio != t_ratio:
+
+                if t_ratio < 0:
                     raise Exception(
-                        "Transmission {} has a different reduction ratio (not supported)".format(
-                            t_ratio
-                        )
+                        "Thruster mapper does not allow negative mechanical reduction."
                     )
-                ratio = t_ratio
+                
+                ratio[i] = t_ratio
+
                 joint = None
                 for t_joint in urdf.joints:
                     if t_joint.name == transmission.joints[0].name:

--- a/NaviGator/gnc/navigator_thrust_mapper/navigator_thrust_mapper/thruster_map.py
+++ b/NaviGator/gnc/navigator_thrust_mapper/navigator_thrust_mapper/thruster_map.py
@@ -177,7 +177,9 @@ class ThrusterMap:
 
                 if t_ratio < 0:
                     raise Exception(
-                        "Thruster mapper does not allow negative mechanical reduction."
+                        "Thruster mapper does not allow mechanical reduction of {} for {}.".format(
+                            t_ratio, transmission.name
+                        )
                     )
 
                 ratio[i] = t_ratio

--- a/NaviGator/simulation/navigator_gazebo/urdf/navigator.urdf.xacro
+++ b/NaviGator/simulation/navigator_gazebo/urdf/navigator.urdf.xacro
@@ -28,10 +28,10 @@
   <xacro:include filename="$(find wamv_description)/urdf/thrusters/mil_engine.xacro"/>
   <xacro:property name="thruster_namespace" value="thrusters/"/>
   <!-- === engine === -->
-  <xacro:mil_engine prefix="BL" position="-1.9304 1.1 0.318237" orientation="0.0 0.0 0.785398"/>
-  <xacro:mil_engine prefix="BR" position="-1.9304 -1.1 0.318237" orientation="0.0 0.0 -0.785398"/>
-  <xacro:mil_engine prefix="FL" position="1.46 0.54 0.49675" orientation="0.0 0.0 -0.785398"/>
-  <xacro:mil_engine prefix="FR" position="1.46 -0.54 0.49657" orientation="0.0 0.0 0.785398"/>
+  <xacro:mil_engine prefix="BL" position="-1.9304 1.1 0.318237" orientation="0.0 0.0 0.785398" mech_reduction="1.35"/>
+  <xacro:mil_engine prefix="BR" position="-1.9304 -1.1 0.318237" orientation="0.0 0.0 -0.785398" mech_reduction="1.35"/>
+  <xacro:mil_engine prefix="FL" position="1.46 0.54 0.49675" orientation="0.0 0.0 -0.785398" mech_reduction="1.35"/>
+  <xacro:mil_engine prefix="FR" position="1.46 -0.54 0.49657" orientation="0.0 0.0 0.785398" mech_reduction="1.35"/>
 
   <gazebo>
     <plugin name="wamv_gazebo_thrust" filename="libusv_gazebo_thrust_plugin.so">


### PR DESCRIPTION
## Description
NaviGator now has the ability to provide different mechanical reductions to each thruster. This means, if one thruster (for some reason is outputting less force than another given the same input current, we can modify the ratio that is multiplied by the input provided by the thruster mapper.

## Testing
Go to ```navigator_gazebo/urdf/navigator.urdf.xacro```. Change any of the mechanical reduction parameters in the file. If you try to provide a wrench on the real boat, you will see that one thruster moves slower than another when you provide a forward wrench (which will provide the same input current to each of the thrusters).
