### PR TITLE
Add Python 3 typing to `txros`

### DIFF
--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -103,3 +103,6 @@ startxbox()
 }
 
 alias xbox=startxbox
+
+# PYTHONPATH modifications
+export PYTHONPATH="/home/parallels/catkin_ws/src/mil/mil_common/txros/txros/src:${PYTHONPATH}"

--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -105,4 +105,4 @@ startxbox()
 alias xbox=startxbox
 
 # PYTHONPATH modifications
-export PYTHONPATH="/home/parallels/catkin_ws/src/mil/mil_common/txros/txros/src:${PYTHONPATH}"
+export PYTHONPATH="${HOME}/catkin_ws/src/mil/mil_common/txros/txros/src:${PYTHONPATH}"


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
This PR adds Python 3 typing to `txros`, making it easier for developers to quickly use the library.


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->
None, library changes.


## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closed #XXX" to close the issue when the PR is merged. -->

None

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
Verify that all CI tests pass. You can optionally run `pyright` in the `txros` library folder and observe that no type issues arise (in non-strict mode).


## About This PR
<!-- BELOW: Have you checked the following? --->

- [x] I have updated documentation related to this change so that future members are aware of the changes I've made.