### PR TITLE
Fix accidental literal comparison between command and literal

### DIFF
--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -6,7 +6,7 @@ MIL_REPO="$MIL_WS/src/mil"
 
 # Source ROS and local catkin
 # finds command that initiated the current process
-if [[ "ps -p $$ | tail -n 1 | awk '{ print $4 }'" == "zsh" ]]
+if [[ $(ps -p $$ | tail -n 1 | awk '{ print $4 }') == "zsh" ]]
 then
     # zsh detected, sourcing appropriate setup scripts"
     source /opt/ros/noetic/setup.zsh


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? →
This PR fixes an issue with #935, which accidentally compared a command to a literal value.


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->
Not relevant


## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closed #XXX" to close the issue when the PR is merged. -->

* #XXX

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
Observe that no issues are found when using the shell environment


## About This PR
<!-- BELOW: Have you checked the following? --->

- [ ] I have updated documentation related to this change so that future members are aware of the changes I've made.
