### PR TITLE
Use `ubuntu-20.04` for GitHub Pages generation container

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Wait to let checks appear
         run: sleep 1m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v15.0.6
+    rev: v14.0.6
     hooks:
       - id: clang-format
   - repo: https://github.com/PyCQA/autoflake


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
[Recently, `ubuntu-latest` container was updated to use Ubuntu 20 instead of Ubuntu 22.](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/) As a result, `rsync` has had issues being installed in the GitHub Actions deployment runner.


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->
None, Github Actions only.


## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closed #XXX" to close the issue when the PR is merged. -->

* None

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
None


## About This PR
<!-- BELOW: Have you checked the following? --->

- [x] I have updated documentation related to this change so that future members are aware of the changes I've made.
