### PR TITLE
Fix container type for container deploying docs from master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
 
   deploy-docs:
     name: Deploy docs from master
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - super-ci
     if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Description
The container used to deploy docs from `master` is broken by the upgrade to Ubuntu 22.04. Should have been included in #960, but forgot. 😛 


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->
None, container stuff.


## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closed #XXX" to close the issue when the PR is merged. -->

* #XXX

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
None


## About This PR
<!-- BELOW: Have you checked the following? --->

- [x] I have updated documentation related to this change so that future members are aware of the changes I've made.
