### PR TITLE
Errors in Sphinx compilation will cause build_docs script to fail

### DIFF
--- a/docs/reference/alarms.rst
+++ b/docs/reference/alarms.rst
@@ -94,11 +94,12 @@ ListenerCb
 
 .. doxygenstruct:: ros_alarms::ListenerCb
 
-HeartbeatMonitor
-~~~~~~~~~~~~~~~~
-.. cppattributetable:: ros_alarms::HeartbeatMonitor
+.. Causes sphinx-doc/sphinx#10152
+.. HeartbeatMonitor
+.. ~~~~~~~~~~~~~~~~
+.. .. cppattributetable:: ros_alarms::HeartbeatMonitor
 
-.. doxygenclass:: ros_alarms::HeartbeatMonitor
+.. .. doxygenclass:: ros_alarms::HeartbeatMonitor
 
 Subjugator-specific
 ^^^^^^^^^^^^^^^^^^^

--- a/scripts/build_docs
+++ b/scripts/build_docs
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 usage="$(basename "$0") [-h | --help] [-s | --scratch] [-n | --no-source]
 [-d | --doxygen] -- build MIL docs
 
@@ -56,9 +57,9 @@ fi
 
 if [ "$SCRATCH" = true ]; then
 	#Doxygen
-	NO_SOURCE="$NO_SOURCE" sphinx-build -E -b html -d "$BUILD_DIR"/doctrees "$MIL_DIR"/docs "$BUILD_DIR"/html
+	NO_SOURCE="$NO_SOURCE" sphinx-build -W -E -b html -d "$BUILD_DIR"/doctrees "$MIL_DIR"/docs "$BUILD_DIR"/html
 else
-	NO_SOURCE="$NO_SOURCE" sphinx-build -b html -d "$BUILD_DIR"/doctrees "$MIL_DIR"/docs "$BUILD_DIR"/html
+	NO_SOURCE="$NO_SOURCE" sphinx-build -W -b html -d "$BUILD_DIR"/doctrees "$MIL_DIR"/docs "$BUILD_DIR"/html
 fi
 
 # Then Sphinx build


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
This PR adds a small amount of code to cause the `build_docs` script to fail whenever the Sphinx doc compilation fails.


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->
None, basic change.


## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closed #XXX" to close the issue when the PR is merged. -->

* #832

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
See CI output


## About This PR
<!-- BELOW: Have you checked the following? --->

- [ ] I have updated documentation related to this change so that future members are aware of the changes I've made.
