### PR TITLE
Sub now rotates to specific orientation before moving through start gate

### DIFF
--- a/SubjuGator/command/subjugator_launch/config/course_geometry.yaml
+++ b/SubjuGator/command/subjugator_launch/config/course_geometry.yaml
@@ -1,4 +1,10 @@
 ---
-vision:
-  buoy_radius: 0.1
-  channel_width: 0.2
+location:
+  # TRANSDEC values
+  declination: 11
+
+  # Florida Pool values
+  # declination: -6.27
+
+start_gate:
+  orientation: 0

--- a/SubjuGator/command/subjugator_launch/launch/sub8.launch
+++ b/SubjuGator/command/subjugator_launch/launch/sub8.launch
@@ -25,6 +25,11 @@
 
   <include file="$(find subjugator_launch)/launch/can.launch" />
 
+  <!-- Parameters for course-specific geometry -->
+  <group ns="course">
+      <rosparam file="$(find subjugator_launch)/config/course_geometry.yaml" />
+  </group>
+
   <include if="$(eval environment != 'dynsim')" file="$(find subjugator_launch)/launch/subsystems/cameras.launch">
     <arg name="environment" value="$(arg environment)" />
     <arg name="simulate_cams" value="$(arg simulate_cams)" />

--- a/SubjuGator/command/subjugator_missions/subjugator_missions/start_gate_2022.py
+++ b/SubjuGator/command/subjugator_missions/subjugator_missions/start_gate_2022.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 
+import math
+
+from axros import Subscriber
 from mil_misc_tools import text_effects
+from sensor_msgs.msg import MagneticField
+from tf.transformations import *
 
 from .sub_singleton import SubjuGatorMission
 
@@ -12,12 +17,28 @@ CAREFUL_SPEED = 0.3
 
 # How many meters to pass the gate by
 DIST_AFTER_GATE = 1
-WAIT_SECONDS = 180
+WAIT_SECONDS = 1
 
 RIGHT_OR_LEFT = 1
 
 
 class StartGate2022(SubjuGatorMission):
+    async def current_angle(self):
+        imu_sub: Subscriber[MagneticField] = self.nh.subscribe(
+            "/imu/mag", MagneticField
+        )
+        async with imu_sub:
+            reading = await imu_sub.get_next_message()
+        declination = await self.nh.get_param("/course/location/declination")
+        fprint(declination)
+        assert isinstance(declination, float) or isinstance(declination, int)
+        return (
+            math.atan2(reading.magnetic_field.z, reading.magnetic_field.y)
+            * 180
+            / math.pi
+            + declination
+        )
+
     async def run(self, args):
         fprint("Waiting for odom")
         await self.tx_pose()
@@ -25,9 +46,22 @@ class StartGate2022(SubjuGatorMission):
         fprint(f"Waiting {WAIT_SECONDS} seconds...")
         await self.nh.sleep(WAIT_SECONDS)
 
+        orientation = await self.nh.get_param("/course/start_gate/orientation")
+        fprint(f"Rotating to start gate orientation (of {orientation} degrees)...")
+        cur_degree = await self.current_angle()
+        fprint(f"Current degree: {cur_degree} degrees")
+        assert isinstance(orientation, int)
+        if cur_degree > orientation:
+            fprint(f"Yaw lefting: {cur_degree - orientation} degrees")
+            await self.move.yaw_left_deg(cur_degree - orientation).go()
+        else:
+            fprint(f"Yaw righting: {orientation - cur_degree} degrees")
+            await self.move.yaw_right_deg(orientation - cur_degree).go()
+        await self.nh.sleep(2)  # Give sub time to turn before moving straight
+
         fprint("Found odom")
         down = self.move.down(1).zero_roll_and_pitch()
-        forward = self.move.forward(4).zero_roll_and_pitch()
-
         await down.go(speed=SPEED)
+
+        forward = self.move.forward(4).zero_roll_and_pitch()
         await forward.go(speed=SPEED)


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
This PR adds the ability for the sub to rotate to a specific orientation before moving through the start gate. This is used for the "Coin Flip" task, where the sub could start in any orientation before being required to move through the start gate.


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->
https://user-images.githubusercontent.com/52760912/223162810-55a03d85-3d75-4c26-a66a-e732acc03d67.mp4



## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closed #XXX" to close the issue when the PR is merged. -->

* #992

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
Run the `StartGate2022` mission and observe that the sub orients to a specific direction first.


## About This PR
<!-- BELOW: Have you checked the following? --->

- [ ] I have updated documentation related to this change so that future members are aware of the changes I've made.
