### PR TITLE
Run apt-get update before upgrade

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -50,7 +50,7 @@ jobs:
       # We need to install rsync for GitHub Pages deploy action
       - name: Install rsync
         run: |
-          sudo apt-get upgrade && sudo apt-get update && sudo apt-get install -y rsync
+          sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y rsync
 
       - name: Move folders
         if: github.event.action != 'closed'


### PR DESCRIPTION
The package index from the runner image will go out of date and dependencies may be unresolveable. If upgrade is run before update the index can be stale for the upgrade step.

## Description
Updated order of commands in install rsync step of gh pages ci.


## Related Issues
Closes #1000 

## Testing
If CI build completes, the issue is resolved. The issue is intermittent, and depends on the state of the runner container's last update time.



## About This PR
- [x] I have updated documentation related to this change so that future members are aware of the changes I've made.
