### PR TITLE
Amends PR template to link to issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,9 +9,9 @@
 
 
 ## Related Issues
-<!-- BELOW: What issues are closed by this PR? Write "Closed #XXX" to close the issue when the PR is merged. -->
+<!-- BELOW: What issues are closed by this PR? Write "Closes #XXX" to link the issue to the PR and close it when the PR is merged. -->
 
-* #XXX
+\- Closes #XXX
 
 ## Testing
 <!-- BELOW: Briefly explain how someone can go about testing your PR. -->


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
Resolves #1004 by changing the PR template to use a '-' instead of a bullet point under the "Related Issues" section, and promoting the use of Github's keywords by explicitly saying "Closes \#XXX" to link the PR to the corresponding issue.


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->



## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closed #XXX" to close the issue when the PR is merged. -->

* Closes #1004 

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
After merging to master, ensure that the new template is used when submitting a new PR, and properly links to the correct issue.


## About This PR
<!-- BELOW: Have you checked the following? --->

- [ ] I have updated documentation related to this change so that future members are aware of the changes I've made.
