### PR TITLE
Add support for CMake 3.2

### DIFF
--- a/NaviGator/docs/CMakeLists.txt
+++ b/NaviGator/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_documentation)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/NaviGator/gnc/navigator_controller/CMakeLists.txt
+++ b/NaviGator/gnc/navigator_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_controller)
 
 find_package(catkin REQUIRED

--- a/NaviGator/gnc/navigator_msg_multiplexer/CMakeLists.txt
+++ b/NaviGator/gnc/navigator_msg_multiplexer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_msg_multiplexer)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/NaviGator/gnc/navigator_path_planner/CMakeLists.txt
+++ b/NaviGator/gnc/navigator_path_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_path_planner)
 find_package(catkin
   REQUIRED

--- a/NaviGator/gnc/navigator_thrust_mapper/CMakeLists.txt
+++ b/NaviGator/gnc/navigator_thrust_mapper/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_thrust_mapper)
 
 find_package(catkin REQUIRED)

--- a/NaviGator/hardware_drivers/navigator_kill_board/CMakeLists.txt
+++ b/NaviGator/hardware_drivers/navigator_kill_board/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_kill_board)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/NaviGator/mission_control/navigator_alarm/CMakeLists.txt
+++ b/NaviGator/mission_control/navigator_alarm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_alarm)
 
 find_package(catkin REQUIRED

--- a/NaviGator/mission_control/navigator_launch/CMakeLists.txt
+++ b/NaviGator/mission_control/navigator_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_launch)
 find_package(catkin REQUIRED roslaunch)
 roslaunch_add_file_check(launch)

--- a/NaviGator/mission_control/navigator_missions/CMakeLists.txt
+++ b/NaviGator/mission_control/navigator_missions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_missions)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/NaviGator/perception/navigator_vision/CMakeLists.txt
+++ b/NaviGator/perception/navigator_vision/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_vision)
 
 # SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")

--- a/NaviGator/satellite/rviz_satellite/CMakeLists.txt
+++ b/NaviGator/satellite/rviz_satellite/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rviz_satellite)
 
 set(DISTRO $ENV{ROS_DISTRO})

--- a/NaviGator/simulation/navigator_gazebo/CMakeLists.txt
+++ b/NaviGator/simulation/navigator_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_gazebo)
 
 find_package(catkin

--- a/NaviGator/simulation/navigator_gazebo/CMakeLists.txt
+++ b/NaviGator/simulation/navigator_gazebo/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(navigator_gazebo)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(catkin
     REQUIRED COMPONENTS
     navigator_msgs
@@ -30,7 +33,7 @@ add_library(
     navigator_thrusters
         src/navigator_thrusters.cpp
 )
-set_target_properties(navigator_thrusters PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")
+set_target_properties(navigator_thrusters PROPERTIES COMPILE_FLAGS "-std=c++17 -Wall")
 target_link_libraries(navigator_thrusters
   ${catkin_LIBRARIES}
   ${GAZEBO_LIBRARIES}
@@ -43,7 +46,7 @@ add_library(
     pinger_plugin
         src/pinger_plugin.cpp
 )
-set_target_properties(pinger_plugin PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")
+set_target_properties(pinger_plugin PROPERTIES COMPILE_FLAGS "-std=c++17 -Wall")
 target_link_libraries(pinger_plugin
   ${catkin_LIBRARIES}
   ${GAZEBO_LIBRARIES}
@@ -55,7 +58,7 @@ add_dependencies(pinger_plugin
 add_library(sylphase_gazebo
   src/sylphase_gazebo.cpp
 )
-set_target_properties(sylphase_gazebo PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")
+set_target_properties(sylphase_gazebo PROPERTIES COMPILE_FLAGS "-std=c++17 -Wall")
 target_link_libraries(sylphase_gazebo
   ${catkin_LIBRARIES}
   ${GAZEBO_LIBRARIES}

--- a/NaviGator/test/navigator_test/CMakeLists.txt
+++ b/NaviGator/test/navigator_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_test)
 find_package(catkin REQUIRED COMPONENTS
 )

--- a/NaviGator/utils/navigator_battery_monitor/CMakeLists.txt
+++ b/NaviGator/utils/navigator_battery_monitor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_battery_monitor)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/NaviGator/utils/navigator_gui/CMakeLists.txt
+++ b/NaviGator/utils/navigator_gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_gui)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/NaviGator/utils/navigator_judgepanel/CMakeLists.txt
+++ b/NaviGator/utils/navigator_judgepanel/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_judgespanel)
 
 ## Find catkin macros and libraries

--- a/NaviGator/utils/navigator_msgs/CMakeLists.txt
+++ b/NaviGator/utils/navigator_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/NaviGator/utils/navigator_robotx_comms/CMakeLists.txt
+++ b/NaviGator/utils/navigator_robotx_comms/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_robotx_comms)
 
 ## Find catkin macros and libraries

--- a/NaviGator/utils/navigator_tools/CMakeLists.txt
+++ b/NaviGator/utils/navigator_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_tools)
 find_package(catkin
   REQUIRED COMPONENTS

--- a/NaviGator/utils/remote_control/navigator_emergency_control/CMakeLists.txt
+++ b/NaviGator/utils/remote_control/navigator_emergency_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_emergency_controller)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/NaviGator/utils/remote_control/navigator_joystick_control/CMakeLists.txt
+++ b/NaviGator/utils/remote_control/navigator_joystick_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_joystick_control)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/NaviGator/utils/remote_control/navigator_keyboard_control/CMakeLists.txt
+++ b/NaviGator/utils/remote_control/navigator_keyboard_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_keyboard_control)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/NaviGator/utils/voltage_gui/CMakeLists.txt
+++ b/NaviGator/utils/voltage_gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(voltage_gui)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/SubjuGator/command/subjugator_alarm/CMakeLists.txt
+++ b/SubjuGator/command/subjugator_alarm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(subjugator_alarm)
 

--- a/SubjuGator/command/subjugator_launch/CMakeLists.txt
+++ b/SubjuGator/command/subjugator_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_launch)
 find_package(catkin REQUIRED roslaunch)
 roslaunch_add_file_check(launch)

--- a/SubjuGator/command/subjugator_missions/CMakeLists.txt
+++ b/SubjuGator/command/subjugator_missions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_missions)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/SubjuGator/docs/CMakeLists.txt
+++ b/SubjuGator/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_documentation)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/SubjuGator/drivers/magnetic_compensation/sub8_magnetic_dynamic_compensation/CMakeLists.txt
+++ b/SubjuGator/drivers/magnetic_compensation/sub8_magnetic_dynamic_compensation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(magnetic_dynamic_compensation)
 find_package(catkin REQUIRED COMPONENTS message_generation geometry_msgs roscpp tf std_msgs message_runtime nodelet)
 

--- a/SubjuGator/drivers/magnetic_compensation/sub8_magnetic_hardsoft_compensation/CMakeLists.txt
+++ b/SubjuGator/drivers/magnetic_compensation/sub8_magnetic_hardsoft_compensation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(magnetic_hardsoft_compensation)
 find_package(catkin REQUIRED COMPONENTS tf geometry_msgs nodelet roscpp mil_tools eigen_conversions)
 

--- a/SubjuGator/drivers/sub8_actuator_board/CMakeLists.txt
+++ b/SubjuGator/drivers/sub8_actuator_board/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(sub8_actuator_board)
 find_package(catkin REQUIRED COMPONENTS
   message_generation

--- a/SubjuGator/drivers/sub8_adis16400_imu/CMakeLists.txt
+++ b/SubjuGator/drivers/sub8_adis16400_imu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(adis16400_imu)
 find_package(catkin REQUIRED COMPONENTS sensor_msgs geometry_msgs nodelet roscpp mil_tools)
 catkin_package(

--- a/SubjuGator/drivers/sub8_depth_driver/CMakeLists.txt
+++ b/SubjuGator/drivers/sub8_depth_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(depth_driver)
 find_package(catkin REQUIRED COMPONENTS nodelet roscpp mil_msgs mil_tools)
 

--- a/SubjuGator/drivers/sub8_driver_utils/camera_utils/CMakeLists.txt
+++ b/SubjuGator/drivers/sub8_driver_utils/camera_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(camera_utils)
 
 # This builds a utility to reset the camera bus using the DC1394 camera libraries

--- a/SubjuGator/drivers/sub8_rdi_dvl/CMakeLists.txt
+++ b/SubjuGator/drivers/sub8_rdi_dvl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rdi_explorer_dvl)
 find_package(catkin REQUIRED COMPONENTS nodelet roscpp mil_msgs mil_tools)
 catkin_package(

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/CMakeLists.txt
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(sub8_thrust_and_kill_board)
 find_package(catkin REQUIRED COMPONENTS
   mil_usb_to_can

--- a/SubjuGator/gnc/c3_trajectory_generator/CMakeLists.txt
+++ b/SubjuGator/gnc/c3_trajectory_generator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(c3_trajectory_generator)
 
 find_package(catkin

--- a/SubjuGator/gnc/rise_6dof/CMakeLists.txt
+++ b/SubjuGator/gnc/rise_6dof/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rise_6dof)
 find_package(catkin REQUIRED COMPONENTS nav_msgs dynamic_reconfigure message_runtime message_generation rospy mil_msgs tf geometry_msgs)
 catkin_python_setup()

--- a/SubjuGator/gnc/subjugator_controller/CMakeLists.txt
+++ b/SubjuGator/gnc/subjugator_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_controller)
 find_package(catkin REQUIRED dynamic_reconfigure)
 catkin_python_setup()

--- a/SubjuGator/gnc/subjugator_system_id/CMakeLists.txt
+++ b/SubjuGator/gnc/subjugator_system_id/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_system_id)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/SubjuGator/gnc/subjugator_thruster_mapper/CMakeLists.txt
+++ b/SubjuGator/gnc/subjugator_thruster_mapper/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_thruster_mapper)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/SubjuGator/perception/subjugator_perception/CMakeLists.txt
+++ b/SubjuGator/perception/subjugator_perception/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_perception)
 
 SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")

--- a/SubjuGator/perception/subjugator_pointcloud/CMakeLists.txt
+++ b/SubjuGator/perception/subjugator_pointcloud/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_pointcloud)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/SubjuGator/simulation/subjugator_gazebo/CMakeLists.txt
+++ b/SubjuGator/simulation/subjugator_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_gazebo)
 
 # SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -Wall")

--- a/SubjuGator/simulation/subjugator_gazebo/CMakeLists.txt
+++ b/SubjuGator/simulation/subjugator_gazebo/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_gazebo)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -Wall")
-# SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+# SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
 find_package(catkin
     REQUIRED COMPONENTS
@@ -29,7 +32,7 @@ add_library(
     subjugator_buoyancy
         src/subjugator_buoyancy.cc
 )
-set_target_properties(subjugator_buoyancy PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")
+set_target_properties(subjugator_buoyancy PROPERTIES COMPILE_FLAGS "-std=c++17 -Wall")
 target_link_libraries(
     subjugator_buoyancy
         ${catkin_LIBRARIES}
@@ -40,7 +43,7 @@ add_library(
     subjugator_liftdrag
         src/subjugator_liftdrag.cc
 )
-set_target_properties(subjugator_liftdrag PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")
+set_target_properties(subjugator_liftdrag PROPERTIES COMPILE_FLAGS "-std=c++17 -Wall")
 target_link_libraries(
     subjugator_liftdrag
         ${catkin_LIBRARIES}
@@ -52,7 +55,7 @@ add_library(
         src/subjugator_thrusters.cc
         src/subjugator_thruster_config.cpp
 )
-set_target_properties(subjugator_thrusters PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")
+set_target_properties(subjugator_thrusters PROPERTIES COMPILE_FLAGS "-std=c++17 -Wall")
 target_link_libraries(
     subjugator_thrusters
         ${catkin_LIBRARIES}
@@ -63,7 +66,7 @@ add_library(
     subjugator_state_set
         src/subjugator_state_set.cpp
 )
-set_target_properties(subjugator_state_set PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")
+set_target_properties(subjugator_state_set PROPERTIES COMPILE_FLAGS "-std=c++17 -Wall")
 target_link_libraries(
     subjugator_state_set
         ${catkin_LIBRARIES}
@@ -93,7 +96,7 @@ add_library(
     subjugator_test
         src/subjugator_test.cc
 )
-set_target_properties(subjugator_test PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")
+set_target_properties(subjugator_test PROPERTIES COMPILE_FLAGS "-std=c++17 -Wall")
 target_link_libraries(
     subjugator_test
         ${catkin_LIBRARIES}

--- a/SubjuGator/simulation/subjugator_simulation/CMakeLists.txt
+++ b/SubjuGator/simulation/subjugator_simulation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_simulation)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/SubjuGator/utils/subjugator_build_tools/CMakeLists.txt
+++ b/SubjuGator/utils/subjugator_build_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_build_tools)
 
 # Any tools that aid in the building or debugging of source code can be built here

--- a/SubjuGator/utils/subjugator_diagnostics/CMakeLists.txt
+++ b/SubjuGator/utils/subjugator_diagnostics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_diagnostics)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/SubjuGator/utils/subjugator_msgs/CMakeLists.txt
+++ b/SubjuGator/utils/subjugator_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/deprecated/NaviGator/mission_systems/navigator_scan_the_code/CMakeLists.txt
+++ b/deprecated/NaviGator/mission_systems/navigator_scan_the_code/CMakeLists.txt
@@ -1,4 +1,4 @@
-# cmake_minimum_required(VERSION 2.8.3)
+# cmake_minimum_required(VERSION 3.0.2)
 # project(navigator_scan_the_code)
 # find_package(catkin REQUIRED COMPONENTS
 #   rospy

--- a/deprecated/NaviGator/mission_systems/shooter/CMakeLists.txt
+++ b/deprecated/NaviGator/mission_systems/shooter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_shooter)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/deprecated/NaviGator/perception/navigator_lidar_oa/CMakeLists.txt
+++ b/deprecated/NaviGator/perception/navigator_lidar_oa/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_lidar_oa)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/deprecated/NaviGator/simulation/navigator_2dsim/CMakeLists.txt
+++ b/deprecated/NaviGator/simulation/navigator_2dsim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_2dsim)
 catkin_package()
 

--- a/deprecated/NaviGator/utils/navigator_emergency_control/CMakeLists.txt
+++ b/deprecated/NaviGator/utils/navigator_emergency_control/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Catkin User Guide: http://www.ros.org/doc/groovy/api/catkin/html/user_guide/user_guide.html
 # Catkin CMake Standard: http://www.ros.org/doc/groovy/api/catkin/html/user_guide/standards.html
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(navigator_emergency_control)
 # Load catkin and all dependencies required for this package
 # TODO: remove all from COMPONENTS that are not catkin packages.

--- a/deprecated/NaviGator/xbox_joy_node/CMakeLists.txt
+++ b/deprecated/NaviGator/xbox_joy_node/CMakeLists.txt
@@ -1,5 +1,5 @@
 # http://ros.org/doc/groovy/api/catkin/html/user_guide/supposed.html
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(xbox_joy_node)
 
 # Load catkin and all dependencies required for this package

--- a/deprecated/SubjuGator/drivers/sub8_videoray_m5_thruster/CMakeLists.txt
+++ b/deprecated/SubjuGator/drivers/sub8_videoray_m5_thruster/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(sub8_videoray_m5_thruster)
 find_package(catkin REQUIRED COMPONENTS
   rospy

--- a/deprecated/SubjuGator/gnc/sub8_controller/CMakeLists.txt
+++ b/deprecated/SubjuGator/gnc/sub8_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_controller)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/deprecated/SubjuGator/gnc/sub8_system_id/CMakeLists.txt
+++ b/deprecated/SubjuGator/gnc/sub8_system_id/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(subjugator_system_id)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/deprecated/SubjuGator/simulation/sub8_montecarlo/CMakeLists.txt
+++ b/deprecated/SubjuGator/simulation/sub8_montecarlo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(sub8_montecarlo)
 find_package(catkin REQUIRED COMPONENTS
   rospy

--- a/deprecated/SubjuGator/sub8_rqt/CMakeLists.txt
+++ b/deprecated/SubjuGator/sub8_rqt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(sub8_rqt)
 find_package(catkin REQUIRED COMPONENTS
   rospy

--- a/mil_common/drivers/mil_blueview_driver/CMakeLists.txt
+++ b/mil_common/drivers/mil_blueview_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 project(mil_blueview_driver)
 

--- a/mil_common/drivers/mil_passive_sonar/CMakeLists.txt
+++ b/mil_common/drivers/mil_passive_sonar/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mil_passive_sonar)
 find_package(catkin REQUIRED COMPONENTS tf std_msgs message_runtime message_generation rospy geometry_msgs roscpp)
 catkin_python_setup()

--- a/mil_common/drivers/mil_pneumatic_actuator/CMakeLists.txt
+++ b/mil_common/drivers/mil_pneumatic_actuator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mil_pneumatic_actuator)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/mil_common/drivers/mil_usb_to_can/CMakeLists.txt
+++ b/mil_common/drivers/mil_usb_to_can/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mil_usb_to_can)
 find_package(catkin REQUIRED COMPONENTS
   rospy

--- a/mil_common/drivers/sabertooth2x12/CMakeLists.txt
+++ b/mil_common/drivers/sabertooth2x12/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(sabertooth2x12)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/mil_common/gnc/mil_bounds/CMakeLists.txt
+++ b/mil_common/gnc/mil_bounds/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mil_bounds)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/mil_common/gnc/odom_estimator/CMakeLists.txt
+++ b/mil_common/gnc/odom_estimator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(odom_estimator)
 
 find_package(catkin

--- a/mil_common/gnc/odometry_utils/CMakeLists.txt
+++ b/mil_common/gnc/odometry_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(odometry_utils)
 
 find_package(catkin

--- a/mil_common/gnc/rawgps_common/CMakeLists.txt
+++ b/mil_common/gnc/rawgps_common/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Catkin User Guide: http://www.ros.org/doc/groovy/api/catkin/html/user_guide/user_guide.html
 # Catkin CMake Standard: http://www.ros.org/doc/groovy/api/catkin/html/user_guide/standards.html
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rawgps_common)
 # Load catkin and all dependencies required for this package
 # TODO: remove all from COMPONENTS that are not catkin packages.

--- a/mil_common/mil_missions/CMakeLists.txt
+++ b/mil_common/mil_missions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mil_missions)
 find_package(catkin REQUIRED genmsg actionlib_msgs actionlib)
 catkin_python_setup()

--- a/mil_common/perception/mil_mlp/CMakeLists.txt
+++ b/mil_common/perception/mil_mlp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mil_mlp)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/mil_common/perception/mil_vision/CMakeLists.txt
+++ b/mil_common/perception/mil_vision/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mil_vision)
 
 # set c++11 as default, override with target_compile_options()

--- a/mil_common/perception/point_cloud_object_detection_and_recognition/CMakeLists.txt
+++ b/mil_common/perception/point_cloud_object_detection_and_recognition/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(point_cloud_object_detection_and_recognition)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/mil_common/ros_alarms/CMakeLists.txt
+++ b/mil_common/ros_alarms/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ros_alarms)
 
 ## Find catkin macros and libraries

--- a/mil_common/simulation/mil_gazebo/CMakeLists.txt
+++ b/mil_common/simulation/mil_gazebo/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(mil_gazebo)
-add_compile_options(-std=c++11)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(catkin REQUIRED COMPONENTS
   gazebo_dev

--- a/mil_common/simulation/mil_gazebo/CMakeLists.txt
+++ b/mil_common/simulation/mil_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mil_gazebo)
 add_compile_options(-std=c++11)
 

--- a/mil_common/utils/mil_msgs/CMakeLists.txt
+++ b/mil_common/utils/mil_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mil_msgs)
 find_package(catkin
   REQUIRED COMPONENTS

--- a/mil_common/utils/mil_poi/CMakeLists.txt
+++ b/mil_common/utils/mil_poi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mil_poi)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/mil_common/utils/mil_tools/CMakeLists.txt
+++ b/mil_common/utils/mil_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mil_tools)
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -pedantic -Wall -std=c++11")
 


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
This PR makes some minor modifications to the required C++ standard for many packages. Without this change, `cmake 3.2.6` cannot be used with the repository (which is now being rolled out to Focal).


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->
No screenshot, view build logs to ensure build passes.


## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closed #XXX" to close the issue when the PR is merged. -->

* None

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
View build output


## About This PR
<!-- BELOW: Have you checked the following? --->

- [x] I have updated documentation related to this change so that future members are aware of the changes I've made.
