### PR TITLE
Added respawn delay to connector nodes

### DIFF
--- a/SubjuGator/command/subjugator_launch/launch/subsystems/nav_box.launch
+++ b/SubjuGator/command/subjugator_launch/launch/subsystems/nav_box.launch
@@ -7,7 +7,7 @@
 
   <!-- DVL -->
   <group if="$(eval dvl and environment == 'real')">
-    <node pkg="subjugator_launch" type="dvl_conn" name="dvl_conn" respawn="true"/>
+    <node pkg="subjugator_launch" type="dvl_conn" name="dvl_conn" respawn="true" respawn_delay = "10"/>
     <node pkg="nodelet" type="nodelet" name="dvl_driver" args="standalone rdi_explorer_dvl/nodelet">
       <param name="port" type="string" value="/tmp/dvl"/>
       <param name="frame_id" type="string" value="/dvl"/>
@@ -17,7 +17,7 @@
 
   <!-- Depth Sensor -->
   <group if="$(eval depth and environment == 'real')">
-    <node pkg="subjugator_launch" type="depth_conn" name="depth_conn" respawn="true"/>
+    <node pkg="subjugator_launch" type="depth_conn" name="depth_conn" respawn="true" respawn_delay = "10"/>
     <node pkg="nodelet" type="nodelet" name="depth_driver" args="standalone depth_driver/nodelet">
       <param name="port" type="string" value="/tmp/depth"/>
       <param name="frame_id" type="string" value="/depth"/>
@@ -26,7 +26,7 @@
 
   <!-- IMU -->
   <group if="$(arg imu)" >
-    <node if="$(eval environment == 'real')" pkg="subjugator_launch" type="imu_conn" name="imu_conn" respawn="true"/>
+    <node if="$(eval environment == 'real')" pkg="subjugator_launch" type="imu_conn" name="imu_conn" respawn="true" respawn_delay = "10"/>
     <node if="$(eval environment == 'real')" pkg="nodelet" type="nodelet" name="imu_driver"
           args="standalone adis16400_imu/nodelet">
       <param name="port" type="string" value="/tmp/imu"/>


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
I added a respawn delay to the nodes for the DVL, Depth Sensor, and IMU in the nav_box.launch launch file. This means when they encounter an error and close, they should wait 10 seconds before restarting.


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->



## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closes #XXX" to link the issue to the PR and close it when the PR is merged. -->

\- Closes #1035

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
Run main sub8 launch file, and observe that the connection nodes no longer spam errors.


## About This PR
<!-- BELOW: Have you checked the following? --->

- [ ] I have updated documentation related to this change so that future members are aware of the changes I've made.
