### PR TITLE
remove hardcoded thruster name id map from script to it's only in yaml

### DIFF
--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/handle.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/handle.py
@@ -26,7 +26,7 @@ class ThrusterAndKillBoard(CANDeviceHandle):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Initialize thruster mapping from params
-        self.thrusters, self.name2id_map = make_thruster_dictionary(
+        self.thrusters, self.name_to_id = make_thruster_dictionary(
             rospy.get_param("/thruster_layout/thrusters"),
         )
         # Tracks last hw-kill alarm update
@@ -118,7 +118,7 @@ class ThrusterAndKillBoard(CANDeviceHandle):
             effort = self.thrusters[cmd.name].effort_from_thrust(cmd.thrust)
             # Send packet to command specified thruster the specified force
             packet = ThrustPacket.create_thrust_packet(
-                self.name2id_map[cmd.name],
+                self.name_to_id[cmd.name],
                 effort,
             )
             self.send_data(bytes(packet), can_id=THRUST_SEND_ID)

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/handle.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/handle.py
@@ -26,7 +26,7 @@ class ThrusterAndKillBoard(CANDeviceHandle):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Initialize thruster mapping from params
-        self.thrusters = make_thruster_dictionary(
+        self.thrusters, self.name2id_map = make_thruster_dictionary(
             rospy.get_param("/thruster_layout/thrusters"),
         )
         # Tracks last hw-kill alarm update
@@ -118,7 +118,7 @@ class ThrusterAndKillBoard(CANDeviceHandle):
             effort = self.thrusters[cmd.name].effort_from_thrust(cmd.thrust)
             # Send packet to command specified thruster the specified force
             packet = ThrustPacket.create_thrust_packet(
-                ThrustPacket.ID_MAPPING[cmd.name],
+                self.name2id_map[cmd.name],
                 effort,
             )
             self.send_data(bytes(packet), can_id=THRUST_SEND_ID)

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/packets.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/packets.py
@@ -250,41 +250,9 @@ class ThrustPacket(ApplicationPacket):
     Attributes:
         IDENTIFIER (int): The packet identifier, equal to the ordinal value of "T,"
             or 84.
-        ID_MAPPING (Dict[str, int]): A dictionary mapping 3-letter thruster codes
-            to their respective IDs:
-
-            +--------+------+
-            |  Name  |  ID  |
-            +========+======+
-            |  FLH   |  0   |
-            +--------+------+
-            |  FRH   |  1   |
-            +--------+------+
-            |  FLV   |  2   |
-            +--------+------+
-            |  FRV   |  3   |
-            +--------+------+
-            |  BLH   |  4   |
-            +--------+------+
-            |  BRH   |  5   |
-            +--------+------+
-            |  BLV   |  6   |
-            +--------+------+
-            |  BRV   |  7   |
-            +--------+------+
     """
 
     IDENTIFIER = ord("T")
-    ID_MAPPING = {
-        "FLH": 0,
-        "FRH": 1,
-        "FLV": 2,
-        "FRV": 3,
-        "BLH": 4,
-        "BRH": 5,
-        "BLV": 6,
-        "BRV": 7,
-    }
 
     @classmethod
     def create_thrust_packet(cls, thruster_id: int, command: float):

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/thruster.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/thruster.py
@@ -5,12 +5,15 @@ from numpy import clip, polyval
 
 def make_thruster_dictionary(dictionary):
     """
-    Make a dictionary mapping thruster names to :class:`Thruster` objects.
+    Make a dictionary mapping thruster names to :class:`Thruster` objects
+    and a dictionary mapping thruster names to node IDs.
     """
     ret = {}
+    name_id_map = {}
     for thruster, content in dictionary.items():
         ret[thruster] = Thruster.from_dict(content)
-    return ret
+        name_id_map[thruster] = content["node_id"]
+    return ret, name_id_map
 
 
 class Thruster:

--- a/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/thruster.py
+++ b/SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/thruster.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict
+from __future__ import annotations
+
+from typing import Any
 
 from numpy import clip, polyval
 
 
-def make_thruster_dictionary(dictionary):
+def make_thruster_dictionary(dictionary) -> tuple[dict[str, Thruster], dict[str, int]]:
     """
     Make a dictionary mapping thruster names to :class:`Thruster` objects
     and a dictionary mapping thruster names to node IDs.
@@ -30,7 +32,7 @@ class Thruster:
         self.backward_calibration = backward_calibration
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Dict[str, Any]]):
+    def from_dict(cls, data: dict[str, dict[str, Any]]):
         """
         Constructs the class from a dictionary. The dictionary should be formatted
         as so:


### PR DESCRIPTION

## Description
remove hardcoded thruster name id map from script to it's only in `Subjugator/gnc/subjugator_thruster_mapper/config/thruster_layout.yaml` file and not in the yaml and in hardcoded in `SubjuGator/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/packets.py`.

## Testing
- Run the sub normally in hardware
- Change node_id in the yaml file and see the how the effort changes to a different thruster

This simplifies where the ids so no documentation is needed. Ids are only now in the yaml where users should expect them. 