### PR TITLE
Limit TF_REPEATED_DATA messages by checking for repeated transforms

### DIFF
--- a/SubjuGator/simulation/subjugator_gazebo/urdf/sub8.urdf.xacro
+++ b/SubjuGator/simulation/subjugator_gazebo/urdf/sub8.urdf.xacro
@@ -11,8 +11,6 @@
   <xacro:include filename="$(find mil_gazebo)/xacro/passive_sonar.xacro"/>
   <xacro:include filename="$(find mil_gazebo)/xacro/inclinometer.xacro"/>
 
-  <link name="world"/>
-
   <!-- Base link of sub -->
   <link name="base_link">
     <inertial>
@@ -32,11 +30,6 @@
       </geometry>
     </collision>
   </link>
-
-  <joint name="dummy_joint" type="fixed">
-    <parent link="world"/>
-    <child link="base_link"/>
-  </joint>
 
   <!-- Sensors -->
   <xacro:mil_fixed_link name="front_stereo" parent="base_link" xyz="0.2559 0 0.1707" rpy="0 0 0"/>


### PR DESCRIPTION
(finally!) fixes #889!

## Description
This checks to see if a transform has already been published for a transform with a similar timestamp, and if so, ignores it rather than publishing it. This helps to get rid of the `TF_REPEATED_DATA` that spams the console.