### PR TITLE
Removed the assignee and deadline fields from the github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/navigator.yaml
+++ b/.github/ISSUE_TEMPLATE/navigator.yaml
@@ -7,26 +7,6 @@ body:
     attributes:
       value: |
         Hey, thanks for taking the time to add this software issue!
-  - type: input
-    id: assignee
-    attributes:
-      label: Assignee
-      description: >
-        Does this issue need to be completed by a specific person on the team?
-        If so, mention them below.
-      placeholder: ex. @torvalds is already working on this task!
-    validations:
-      required: false
-  - type: input
-    id: deadline
-    attributes:
-      label: Deadline
-      description: >
-        Does this task need a deadline? _If this task is related to a competition,
-        it should have a deadline._
-      placeholder: ex. 2023-12-25
-    validations:
-      required: false
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
I removed the assignee and deadline fields in the navigator.yaml file in .github/ISSUE_TEMPLATE.


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->

![Screenshot 2023-10-09 204519](https://github.com/uf-mil/mil/assets/100006952/07231dfa-f81e-4260-9749-460bec35a75c)

## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closes #XXX" to link the issue to the PR and close it when the PR is merged. --> 

\- Closes #1091 

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->

They can just create a new issue to see that the assignee and deadline fields no longer exist.

## About This PR
<!-- BELOW: Have you checked the following? --->

- [ ] I have updated documentation related to this change so that future members are aware of the changes I've made.
