### PR TITLE
Fix pip3 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
           cd $GITHUB_WORKSPACE/catkin_ws/src/mil
           rm -rf build devel
           export HOME=$GITHUB_WORKSPACE # Temporary fix for setup scripts
+          sudo apt reinstall python3-pip
           ./scripts/install.sh
       # - name: Run catkin_make
       #   run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
       - name: Configure catkin workspace folder structure
         run: |
           mkdir -p $GITHUB_WORKSPACE/catkin_ws/src
+          sudo apt reinstall python3-pip
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,6 @@ jobs:
           cd $GITHUB_WORKSPACE/catkin_ws/src/mil
           rm -rf build devel
           export HOME=$GITHUB_WORKSPACE # Temporary fix for setup scripts
-          sudo apt reinstall python3-pip
           ./scripts/install.sh
       # - name: Run catkin_make
       #   run: |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -185,6 +185,7 @@ EOF
 
 # Documentation dependencies
 mil_system_install python3-pip python3-setuptools
+sudo apt reinstall -y python3-pip
 
 # Disable "automatic updates" Ubuntu prompt (thanks to https://askubuntu.com/a/610623!)
 sudo sed -i 's/Prompt=.*/Prompt=never/' /etc/update-manager/release-upgrades


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
This fixes the `pip3 not found` issue in CI. I think this happened as a result of updating the docker image


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->
Look at the CI logs


## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closes #XXX" to link the issue to the PR and close it when the PR is merged. -->

None

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->

None

## About This PR
<!-- BELOW: Have you checked the following? --->

- [ ] I have updated documentation related to this change so that future members are aware of the changes I've made.
