### PR TITLE
Added Worlds for Task 5 Testing

### DIFF
--- a/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/behind.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/behind.world
@@ -1,0 +1,3970 @@
+<sdf version='1.7'>
+  <world name='vrx_scan_dock_deliver'>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>1</shadows>
+    </scene>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.7242</latitude_deg>
+      <longitude_deg>150.68</longitude_deg>
+      <elevation>0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+    <light name='sun' type='directional'>
+      <cast_shadows>1</cast_shadows>
+      <pose>0 0 10 0 -0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>-453.391 179.995 23.1197 0 0.248344 2.93686</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+    <model name='sydneyregatta'>
+      <pose>0 0 0.2 0 -0 0</pose>
+      <static>1</static>
+      <link name='link'>
+        <visual name='visual_terrain'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Terrain</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_concrete'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>ConcreteDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>DockDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_metal_galvanized'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>MetalGalvanized</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Dock</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_windows_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Windows_Dark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_roof'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>RoofCorrugated</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_wall'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Wall</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_branches'>
+          <geometry>
+            <mesh>
+              <uri>model://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>TreeDiffuse</name>
+              </submesh>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://sydney_regatta/materials/scripts/</uri>
+              <uri>model://sydney_regatta/materials/textures/</uri>
+              <name>SydneyTree/Branch</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta_shore.dae</uri>
+            </mesh>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_0'>
+      <static>1</static>
+      <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_1'>
+      <static>1</static>
+      <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_2'>
+      <static>1</static>
+      <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='antenna'>
+      <static>1</static>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://antenna/meshes/antenna.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.95 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.35</radius>
+              <length>1.9</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+    </model>
+    <model name='ground_station_0'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+    </model>
+    <model name='ground_station_1'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+    </model>
+    <model name='ground_station_2'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+    </model>
+    <model name='blue_projectile'>
+      <link name='link'>
+        <inertial>
+          <mass>0.04</mass>
+          <inertia>
+            <ixx>2.166e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2166</iyy>
+            <iyz>0</iyz>
+            <izz>2166</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://blue_projectile/materials/scripts/blue_projectile.material</uri>
+              <name>blue_projectile/Blue</name>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name='buoyancy_sphere'>
+          <link_name>link</link_name>
+          <pose>0 0 -0.02 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+      </plugin>
+      <pose>-545 60 0.03 0 -0 0</pose>
+    </model>
+    <model name='ocean_waves'>
+      <static>1</static>
+      <plugin name='ocean_waves::wavefield_entity' filename='libWavefieldModelPlugin.so'>
+        <static>0</static>
+        <update_rate>30</update_rate>
+        <size>1000 1000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>5</period>
+          <number>3</number>
+          <scale>2.5</scale>
+          <gain>0.1</gain>
+          <direction>1.0 0.0</direction>
+          <angle>0.4</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name='ocean_waves_link'>
+        <visual name='ocean_waves_visual'>
+          <plugin name='ocean_waves_visual_plugin' filename='libWavefieldVisualPlugin.so'>
+            <enableRtt>1</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>5</period>
+              <number>3</number>
+              <scale>2.5</scale>
+              <gain>0.1</gain>
+              <direction>1.0 0.0</direction>
+              <angle>0.4</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name='ocean_waves_below_visual'>
+          <pose>0 0 -0.05 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <plugin name='wind' filename='libusv_gazebo_wind_plugin.so'>
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector>.5 .5 .33</coeff_vector>
+      </wind_obj>
+      <wind_direction>270</wind_direction>
+      <wind_mean_velocity>0</wind_mean_velocity>
+      <var_wind_gain_constants>0</var_wind_gain_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
+      <random_seed/>
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <model name='robotx_light_buoy'>
+      <pose>-511 218 0.25 0 -0 3.14</pose>
+      <link name='base_link'>
+        <inertial>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <mass>67.15</mass>
+          <inertia>
+            <ixx>13.486</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>13.486</iyy>
+            <iyz>0</iyz>
+            <izz>25.1813</izz>
+          </inertia>
+        </inertial>
+        <visual name='base'>
+          <geometry>
+            <mesh>
+              <uri>file://robotx_light_buoy/mesh/robotx_light_buoy.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='panel_1'>
+          <pose>-0.05 0.09 1.3 0 -0 0.5</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+          <plugin name='lightplugin' filename='liblight_buoy_plugin.so'>
+            <color_1>off</color_1>
+            <color_2>off</color_2>
+            <color_3>off</color_3>
+            <visuals>
+              <visual>robotx_light_buoy::base_link::panel_1</visual>
+              <visual>robotx_light_buoy::base_link::panel_2</visual>
+              <visual>robotx_light_buoy::base_link::panel_3</visual>
+            </visuals>
+            <robot_namespace>vrx</robot_namespace>
+            <topic>light_buoy/shuffle</topic>
+          </plugin>
+        </visual>
+        <visual name='panel_2'>
+          <pose>-0.06 -0.085 1.3 0 0 -0.54719</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <visual name='panel_3'>
+          <pose>0.11 -0.003 1.3 0 -0 1.5472</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision_base'>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='collision_body'>
+          <pose>0 0 0.85 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.4</radius>
+              <length>1.75</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>1000.0</linear_drag>
+        <angular_drag>200.0</angular_drag>
+        <buoyancy name='buoyancy_base'>
+          <link_name>base_link</link_name>
+          <pose>0 0 -0.2 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <buoyancy name='buoyancy_body'>
+          <link_name>base_link</link_name>
+          <pose>0 0 0.8 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.15</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+      </plugin>
+    </model>
+    <plugin name='contain_placard1_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard1_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='scan_dock__deliver_scoring_plugin' filename='libscan_dock_scoring_plugin.so'>
+      <vehicle>wamv</vehicle>
+      <task_name>scan_dock_deliver</task_name>
+      <initial_state_duration>3</initial_state_duration>
+      <ready_state_duration>3</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <robot_namespace>vrx</robot_namespace>
+      <color_sequence_service>scan_dock_deliver/color_sequence</color_sequence_service>
+      <color_1>blue</color_1>
+      <color_2>green</color_2>
+      <color_3>red</color_3>
+      <dock_bonus_points>15</dock_bonus_points>
+      <correct_dock_bonus_points>5</correct_dock_bonus_points>
+      <bays>
+        <bay>
+          <name>bay1</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>red_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay2</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>1</dock_allowed>
+          <symbol>blue_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay3</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>yellow_rectangle</symbol>
+        </bay>
+      </bays>
+      <targets>
+        <target>
+          <topic>vrx/dock_2022_placard1_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard1_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+      </targets>
+    </plugin>
+    <plugin name='vehicle_docked_bay1' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay1_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+    <physics type='ode'>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+    </physics>
+    <wind/>
+    <model name='wamv'>
+      <link name='wamv/base_link'>
+        <inertial>
+          <pose>0.012722 0 0.026171 0 -0 0</pose>
+          <mass>182.806</mass>
+          <inertia>
+            <ixx>128.232</ixx>
+            <ixy>-2.4178e-21</ixy>
+            <ixz>-3.85993</ixz>
+            <iyy>403.15</iyy>
+            <iyz>-9.28107e-22</iyz>
+            <izz>447.942</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_collision_collision'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_collision_collision_1'>
+          <pose>0.95 0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_lens_collision_collision_2'>
+          <pose>0.987607 0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_box_collision_collision_3'>
+          <pose>0.949948 0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_collision_collision_4'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_collision_collision_5'>
+          <pose>0.95 -0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_lens_collision_collision_6'>
+          <pose>0.987607 -0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_box_collision_collision_7'>
+          <pose>0.949948 -0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_collision_collision_8'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_collision_collision_9'>
+          <pose>0.734 0 1.95 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_collision_collision_10'>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.075</length>
+              <radius>0.055</radius>
+            </cylinder>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <friction>
+              <ode/>
+              <torsional>
+                <ode/>
+              </torsional>
+            </friction>
+            <bounce/>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_float_collision_11'>
+          <pose>-0.4 1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_mid_float_collision_12'>
+          <pose>1.85 1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_front_float_collision_13'>
+          <pose>2.3 1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_lower_collision_14'>
+          <pose>0.9 0.85 1 0.78 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_upper_collision_15'>
+          <pose>0.9 0.6 1.18 1.35 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_lower_collision_16'>
+          <pose>-0.65 0.99 0.7 0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_medium_collision_17'>
+          <pose>-0.57 0.87 1.05 0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_upper_collision_18'>
+          <pose>-0.55 0.65 1.17 1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_lower_collision_19'>
+          <pose>-0.74 1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_medium_collision_20'>
+          <pose>-0.79 0.91 1.05 0.75 -0.15 -0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_upper_collision_21'>
+          <pose>-0.81 0.67 1.18 1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_joint_collision_22'>
+          <pose>0.58 1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_float_collision_23'>
+          <pose>-0.4 -1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_mid_float_collision_24'>
+          <pose>1.85 -1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_front_float_collision_25'>
+          <pose>2.3 -1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_lower_collision_26'>
+          <pose>0.9 -0.85 1 -0.78 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_upper_collision_27'>
+          <pose>0.9 -0.6 1.18 -1.35 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_lower_collision_28'>
+          <pose>-0.65 -0.99 0.7 -0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_medium_collision_29'>
+          <pose>-0.57 -0.87 1.05 -0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_upper_collision_30'>
+          <pose>-0.55 -0.65 1.17 -1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_lower_collision_31'>
+          <pose>-0.74 -1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_medium_collision_32'>
+          <pose>-0.79 -0.91 1.05 -0.75 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_upper_collision_33'>
+          <pose>-0.81 -0.67 1.18 -1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_joint_collision_34'>
+          <pose>0.58 -1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__top_base_collision_35'>
+          <pose>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.85 1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__hydrophones_collision_collision_36'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_left_cam_post_link_visual'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_visual_visual_1'>
+          <pose>0.912 0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_visual_visual_2'>
+          <pose>0.937721 0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_right_cam_post_link_visual_3'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_visual_visual_4'>
+          <pose>0.912 -0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_visual_visual_5'>
+          <pose>0.937721 -0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_link_visual_6'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_visual_visual_7'>
+          <pose>0.696 0 1.947 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_visual_visual_8'>
+          <pose>0.764941 0 1.96619 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/3d_lidar/mesh/3d_lidar.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/dummy_link_visual_9'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/WAM-V-Base/mesh/WAM-V-Base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/hydrophones_visual_10'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name='front_left_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_left_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_left_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_left_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_left_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='front_right_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_right_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_right_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_right_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_right_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 -0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='velodyne_sensor' type='gpu_ray'>
+          <update_rate>10</update_rate>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>18750</samples>
+                <resolution>0.1</resolution>
+                <min_angle>-3.14159</min_angle>
+                <max_angle>3.14159</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>16</samples>
+                <resolution>1</resolution>
+                <min_angle>-0.261799</min_angle>
+                <max_angle>0.261799</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>0.1</min>
+              <max>130</max>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.01</stddev>
+            </noise>
+          </ray>
+          <plugin name='velodyne_plugin' filename='libgazebo_ros_velodyne_gpu_laser.so'>
+            <topicName>velodyne_points</topicName>
+            <frameName>velodyne</frameName>
+            <min_intensity>0</min_intensity>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+        </sensor>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 1.1 0.318237 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_engine_link'>
+        <pose relative_to='BL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BL_engine_link</parent>
+        <child>BL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_propeller_link'>
+        <pose relative_to='BL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_propeller_link_fixed_joint_lump__BL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 -1.1 0.318237 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_engine_link'>
+        <pose relative_to='BR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BR_engine_link</parent>
+        <child>BR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_propeller_link'>
+        <pose relative_to='BR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_propeller_link_fixed_joint_lump__BR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 0.54 0.49675 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_engine_link'>
+        <pose relative_to='FL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FL_engine_link</parent>
+        <child>FL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_propeller_link'>
+        <pose relative_to='FL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_propeller_link_fixed_joint_lump__FL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 -0.54 0.49657 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_engine_link'>
+        <pose relative_to='FR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FR_engine_link</parent>
+        <child>FR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_propeller_link'>
+        <pose relative_to='FR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_propeller_link_fixed_joint_lump__FR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_base_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.54 0.3 1.3 0 -0 0.1</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ball_shooter_base_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_base_link'>
+        <pose relative_to='wamv/ball_shooter_base_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>-0.02 0 0.05 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00083</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00052083</iyy>
+            <iyz>0</iyz>
+            <izz>0.00052083</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/ball_shooter_base_link_fixed_joint_lump__ball_shooter_base_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_launcher_joint' type='revolute'>
+        <pose relative_to='wamv/ball_shooter_base_link'>-0.0204 0 0.107877 0 -0.8 0</pose>
+        <parent>wamv/ball_shooter_base_link</parent>
+        <child>wamv/ball_shooter_launcher_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_launcher_link'>
+        <pose relative_to='wamv/ball_shooter_launcher_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 3.14159 -1.57079 3.14159</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00177917</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00177917</iyy>
+            <iyz>0</iyz>
+            <izz>0.000225</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_collision_collision'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <box>
+              <size>0.3 0.3 0.2</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_launcher_visual_visual'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_launcher.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/imu_wamv_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/imu_wamv_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/imu_wamv_link'>
+        <pose relative_to='wamv/imu_wamv_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.1</mass>
+          <inertia>
+            <ixx>8.3e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>8.3e-05</iyy>
+            <iyz>0</iyz>
+            <izz>0.0125</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/imu_wamv_link_fixed_joint_lump__imu_wamv_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.05 0.025 0.005</size>
+            </box>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ins_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ins_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ins_link'>
+        <pose relative_to='wamv/ins_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.006458</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.006458</iyy>
+            <iyz>0</iyz>
+            <izz>0.01125</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_base_collision'>
+          <pose>0 0 0.025 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.05</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_antenna_collision_1'>
+          <pose>0 0 0.11 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.15</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ins_link_fixed_joint_lump__ins_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_gazebo/models/gps/mesh/gps.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='gps_plugin_ins' filename='libhector_gazebo_ros_gps.so'>
+        <updateRate>15</updateRate>
+        <alwaysOn>1</alwaysOn>
+        <bodyName>wamv/ins_link</bodyName>
+        <frameId>wamv/ins_link</frameId>
+        <topicName>wamv/sensors/gps/gps/fix</topicName>
+        <velocityTopicName>wamv/sensors/gps/gps/fix_velocity</velocityTopicName>
+        <useWorldSphericalCoordinates>1</useWorldSphericalCoordinates>
+        <offset>0.0 0.0 0.0</offset>
+        <drift>0.0 0.0 0.0</drift>
+        <gaussianNoise>0 0 0</gaussianNoise>
+        <velocityOffset>0.0 0.0 0.0</velocityOffset>
+        <velocityDrift>0.0 0.0 0.0</velocityDrift>
+        <velocityGaussianNoise>0.0 0.0 0.0</velocityGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='imu_plugin_imu_wamv' filename='libhector_gazebo_ros_imu.so'>
+        <updateRate>15</updateRate>
+        <bodyName>wamv/imu_wamv_link</bodyName>
+        <topicName>wamv/sensors/imu/imu/data</topicName>
+        <serviceName>wamv/sensors/imu_service</serviceName>
+        <frameId>wamv/imu_wamv_link</frameId>
+        <alwaysOn>1</alwaysOn>
+        <accelOffset>0.0 0.0 0.0</accelOffset>
+        <accelDrift>0.0 0.0 0.0</accelDrift>
+        <accelDriftFrequency>0.00027 0.00027 0.000027</accelDriftFrequency>
+        <accelGaussianNoise>0.0 0.0 0.0</accelGaussianNoise>
+        <rateOffset>0.0 0.0 0.0</rateOffset>
+        <rateDrift>0.0 0.0 0.0</rateDrift>
+        <rateDriftFrequency>0.00027 0.00027 0.000027</rateDriftFrequency>
+        <rateGaussianNoise>0.0 0.0 0.0</rateGaussianNoise>
+        <yawOffset>0.0</yawOffset>
+        <yawDrift>0.0</yawDrift>
+        <yawDriftFrequency>0.00027</yawDriftFrequency>
+        <yawGaussianNoise>0.0</yawGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='ball_shooter_plugin' filename='libball_shooter_plugin.so'>
+        <projectile>
+          <model_name>blue_projectile</model_name>
+          <link_name>link</link_name>
+          <frame>wamv/ball_shooter_launcher_link</frame>
+          <pose>0.14 0 0 0 0 0</pose>
+        </projectile>
+        <num_shots>4</num_shots>
+        <shot_force>300</shot_force>
+        <topic>wamv/shooters/ball_shooter/fire</topic>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='pinger_plugin' filename='libusv_gazebo_acoustic_pinger_plugin.so'>
+        <frameId>wamv/pinger</frameId>
+        <topicName>wamv/sensors/pingers/hydrophones/range_bearing</topicName>
+        <setPositionTopicName>wamv/sensors/pingers/hydrophones/set_pinger_position</setPositionTopicName>
+        <rangeNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>3.0</stddev>
+          </noise>
+        </rangeNoise>
+        <bearingNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </bearingNoise>
+        <elevationNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </elevationNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='wamv_gazebo_thrust' filename='libusv_gazebo_thrust_plugin.so'>
+        <cmdTimeout>1.0</cmdTimeout>
+        <robotNamespace>wamv</robotNamespace>
+        <thruster>
+          <linkName>BL_propeller_link</linkName>
+          <propJointName>BL_engine_propeller_joint</propJointName>
+          <engineJointName>BL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>BR_propeller_link</linkName>
+          <propJointName>BR_engine_propeller_joint</propJointName>
+          <engineJointName>BR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FL_propeller_link</linkName>
+          <propJointName>FL_engine_propeller_joint</propJointName>
+          <engineJointName>FL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FR_propeller_link</linkName>
+          <propJointName>FR_engine_propeller_joint</propJointName>
+          <engineJointName>FR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+      </plugin>
+      <plugin name='usv_dynamics_wamv_dynamics_plugin' filename='libusv_gazebo_dynamics_plugin.so'>
+        <bodyName>wamv/base_link</bodyName>
+        <waterLevel>0</waterLevel>
+        <waterDensity>997.8</waterDensity>
+        <xDotU>0.0</xDotU>
+        <yDotV>0.0</yDotV>
+        <nDotR>0.0</nDotR>
+        <xU>51.3</xU>
+        <xUU>72.4</xUU>
+        <yV>40.0</yV>
+        <yVV>0.0</yVV>
+        <zW>500.0</zW>
+        <kP>50.0</kP>
+        <mQ>50.0</mQ>
+        <nR>400.0</nR>
+        <nRR>0.0</nRR>
+        <hullRadius>0.213</hullRadius>
+        <boatWidth>2.4</boatWidth>
+        <boatLength>4.9</boatLength>
+        <length_n>2</length_n>
+        <wave_model>ocean_waves</wave_model>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <frame name='wamv/front_left_cam_to_front_left_cam_link_optical_joint' attached_to='wamv/front_left_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link_optical' attached_to='wamv/front_left_cam_to_front_left_cam_link_optical_joint'/>
+      <frame name='wamv/front_left_cam_post_arm_to_front_left_cam_joint' attached_to='wamv/front_left_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link' attached_to='wamv/front_left_cam_post_arm_to_front_left_cam_joint'/>
+      <frame name='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint' attached_to='wamv/front_left_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_arm_link' attached_to='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_left_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_link' attached_to='wamv/base_to_front_left_cam_post_joint'/>
+      <frame name='wamv/front_right_cam_to_front_right_cam_link_optical_joint' attached_to='wamv/front_right_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link_optical' attached_to='wamv/front_right_cam_to_front_right_cam_link_optical_joint'/>
+      <frame name='wamv/front_right_cam_post_arm_to_front_right_cam_joint' attached_to='wamv/front_right_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link' attached_to='wamv/front_right_cam_post_arm_to_front_right_cam_joint'/>
+      <frame name='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint' attached_to='wamv/front_right_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_arm_link' attached_to='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_right_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_link' attached_to='wamv/base_to_front_right_cam_post_joint'/>
+      <frame name='wamv/velodyne_post_arm_to_velodyne_joint' attached_to='velodyne_post_arm_link'>
+        <pose>0.04 0 0.05 0 0.261799 0</pose>
+      </frame>
+      <frame name='velodyne' attached_to='wamv/velodyne_post_arm_to_velodyne_joint'/>
+      <frame name='wamv/velodyne_post_to_velodyne_post_arm_joint' attached_to='velodyne_post_link'>
+        <pose>0.03 0 0.32675 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_arm_link' attached_to='wamv/velodyne_post_to_velodyne_post_arm_joint'/>
+      <frame name='wamv/base_to_velodyne_post_joint' attached_to='wamv/base_link'>
+        <pose>0.704 0 1.62325 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_link' attached_to='wamv/base_to_velodyne_post_joint'/>
+      <frame name='wamv/dummy_joint' attached_to='wamv/base_link'>
+        <pose>0 0 0 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/dummy_link' attached_to='wamv/dummy_joint'/>
+      <frame name='wamv/hydrophones_pinger_joint' attached_to='wamv/base_link'>
+        <pose>1 0 -1 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/hydrophones' attached_to='wamv/hydrophones_pinger_joint'/>
+      <pose>-532 162 0.1 0 -0 1</pose>
+    </model>
+    <state world_name='vrx_scan_dock_deliver'>
+      <sim_time>145 475000000</sim_time>
+      <real_time>162 631779676</real_time>
+      <wall_time>1725827437 22701069</wall_time>
+      <iterations>77741</iterations>
+      <model name='antenna'>
+        <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='blue_projectile'>
+        <pose>-545 60 0.053069 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-545 60 0.053069 0 -0 0</pose>
+          <velocity>0 0 -0.032967 0 -0 0</velocity>
+          <acceleration>0 0 0.030588 0 -0 0</acceleration>
+          <wrench>0 0 0.001224 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_0'>
+        <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-540.743 146.687 1.66777 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-539.972 146.474 1.67444 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-541.727 146.128 1.67569 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-541.531 147.215 1.6548 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-540.049 147.325 1.65735 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_1'>
+        <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-537.569 146.021 1.6782 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-536.798 145.808 1.68302 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-538.553 145.462 1.68831 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-538.357 146.549 1.66717 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-536.875 146.659 1.66628 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_2'>
+        <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-534.497 145.103 1.71632 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-533.726 144.89 1.72031 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-535.481 144.545 1.72896 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-535.285 145.632 1.70558 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-533.803 145.741 1.70217 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ocean_waves'>
+        <pose>6.80666 -14.7297 0 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='ocean_waves_link'>
+          <pose>6.80666 -14.7297 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_0'>
+        <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_1'>
+        <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_2'>
+        <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='robotx_light_buoy'>
+        <pose>-527.292 187.46 0.345163 0 -0 3.14</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-527.292 187.46 0.345163 0 -0 3.14</pose>
+          <velocity>0 0 0.058037 0 -0 0</velocity>
+          <acceleration>0 0 -0.019794 0 -0 0</acceleration>
+          <wrench>0 0 -1.32917 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='sydneyregatta'>
+        <pose>0 0 0.2 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>0 0 0.2 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='wamv'>
+        <pose>-524.079 201.114 -0.145295 0.002196 -0.001615 1.00041</pose>
+        <scale>1 1 1</scale>
+        <link name='BL_engine_link'>
+          <pose>-526.047 200.082 0.17224 0.000411 -0.002695 1.78581</pose>
+          <velocity>0.001047 -0.000575 0.023852 0.010629 0.010592 0.000457</velocity>
+          <acceleration>0.012297 0.018258 0.327701 -0.096638 0.063387 -0.002481</acceleration>
+          <wrench>0.184454 0.273867 4.91552 0 -0 0</wrench>
+        </link>
+        <link name='BL_propeller_link'>
+          <pose>-525.988 199.812 -0.337879 0.000411 -0.002695 1.78581</pose>
+          <velocity>-0.004233 0.004874 0.020354 0.010629 0.010592 0.000457</velocity>
+          <acceleration>-0.019109 -0.032011 0.350867 -0.098634 0.061574 0.000258</acceleration>
+          <wrench>-0.009554 -0.016005 0.175434 0 -0 0</wrench>
+        </link>
+        <link name='BR_engine_link'>
+          <pose>-524.195 198.895 0.167408 0.002695 0.000411 0.215027</pose>
+          <velocity>0.001221 -0.000174 -0.008389 0.010629 0.010593 4.9e-05</velocity>
+          <acceleration>0.011694 0.01818 0.330851 -0.098213 0.061156 -0.002552</acceleration>
+          <wrench>0.175405 0.272699 4.96277 0 -0 0</wrench>
+        </link>
+        <link name='BR_propeller_link'>
+          <pose>-524.468 198.836 -0.341847 0.002695 0.000411 0.215027</pose>
+          <velocity>-0.004171 0.005225 -0.006122 0.010629 0.010593 4.9e-05</velocity>
+          <acceleration>-0.019632 -0.032115 0.353456 -0.098635 0.061575 0.000252</acceleration>
+          <wrench>-0.009816 -0.016058 0.176728 0 -0 0</wrench>
+        </link>
+        <link name='FL_engine_link'>
+          <pose>-523.745 202.633 0.354997 0.002695 0.000411 0.215026</pose>
+          <velocity>0.002501 -0.002082 0.026577 0.010629 0.010593 0.000161</velocity>
+          <acceleration>0.023511 0.036316 -0.065684 -0.098189 0.061096 -0.002571</acceleration>
+          <wrench>0.352662 0.544742 -0.985256 0 -0 0</wrench>
+        </link>
+        <link name='FL_propeller_link'>
+          <pose>-524.017 202.575 -0.154257 0.002695 0.000411 0.215026</pose>
+          <velocity>-0.002885 0.003286 0.028844 0.010629 0.010593 0.000161</velocity>
+          <acceleration>-0.007816 -0.013974 -0.04308 -0.098635 0.061575 0.000232</acceleration>
+          <wrench>-0.003908 -0.006987 -0.02154 0 -0 0</wrench>
+        </link>
+        <link name='FR_engine_link'>
+          <pose>-522.836 202.05 0.352445 0.000411 -0.002695 1.78581</pose>
+          <velocity>0.002584 -0.001884 0.010749 0.010629 0.010593 0.00033</velocity>
+          <acceleration>0.023204 0.03626 -0.064137 -0.096663 0.063452 -0.002591</acceleration>
+          <wrench>0.348054 0.543902 -0.96206 0 -0 0</wrench>
+        </link>
+        <link name='FR_propeller_link'>
+          <pose>-522.777 201.78 -0.157673 0.000411 -0.002695 1.78581</pose>
+          <velocity>-0.00273 0.003558 0.007251 0.010629 0.010593 0.00033</velocity>
+          <acceleration>-0.008232 -0.014015 -0.040971 -0.098634 0.061574 0.00015</acceleration>
+          <wrench>-0.004116 -0.007008 -0.020485 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_base_link'>
+          <pose>-524.039 201.727 1.15623 0.002024 -0.001826 1.10041</pose>
+          <velocity>0.01116 -0.010654 0.020061 0.010629 0.010593 0.000188</velocity>
+          <acceleration>0.07588 0.120337 0.043909 -0.154422 0.067003 4.5e-05</acceleration>
+          <wrench>0.03794 0.060169 0.021955 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_launcher_link'>
+          <pose>-524.048 201.709 1.26407 0.002911 -0.801824 1.09832</pose>
+          <velocity>0.012306 -0.011802 0.019962 0.010629 0.010593 0.000188</velocity>
+          <acceleration>0.079444 0.126046 0.043953 0.062522 0.208002 0.170119</acceleration>
+          <wrench>0.039722 0.063023 0.021977 0 -0 0</wrench>
+        </link>
+        <link name='wamv/base_link'>
+          <pose>-524.079 201.114 -0.145295 0.002196 -0.001615 1.00041</pose>
+          <velocity>-0.002512 0.003172 0.013971 0.010629 0.010593 0.000189</velocity>
+          <acceleration>-0.005774 -0.01032 0.103372 -0.514719 -0.223968 -0.007796</acceleration>
+          <wrench>-1.05545 -1.88649 18.897 0 -0 0</wrench>
+        </link>
+        <link name='wamv/imu_wamv_link'>
+          <pose>-524.091 201.404 1.35546 0.002196 -0.001615 1.00041</pose>
+          <velocity>0.013331 -0.012782 0.017181 0.010629 0.010593 0.000189</velocity>
+          <acceleration>0.08505 0.13509 0.076653 -0.09891 0.061857 0.000278</acceleration>
+          <wrench>0.008505 0.013509 0.007665 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ins_link'>
+          <pose>-524.091 201.404 1.35546 0.002196 -0.001615 1.00041</pose>
+          <velocity>0.013331 -0.012782 0.017181 0.010629 0.010593 0.000189</velocity>
+          <acceleration>0.08505 0.13509 0.076653 -0.098635 0.061575 0.000136</acceleration>
+          <wrench>0.08505 0.13509 0.076653 0 -0 0</wrench>
+        </link>
+      </model>
+      <light name='sun'>
+        <pose>0 0 10 0 -0 0</pose>
+      </light>
+    </state>
+  </world>
+</sdf>

--- a/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/close.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/close.world
@@ -1,0 +1,3970 @@
+<sdf version='1.7'>
+  <world name='vrx_scan_dock_deliver'>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>1</shadows>
+    </scene>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.7242</latitude_deg>
+      <longitude_deg>150.68</longitude_deg>
+      <elevation>0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+    <light name='sun' type='directional'>
+      <cast_shadows>1</cast_shadows>
+      <pose>0 0 10 0 -0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>-456.48 162.19 20.7729 0 0.248344 2.93686</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+    <model name='sydneyregatta'>
+      <pose>0 0 0.2 0 -0 0</pose>
+      <static>1</static>
+      <link name='link'>
+        <visual name='visual_terrain'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Terrain</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_concrete'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>ConcreteDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>DockDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_metal_galvanized'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>MetalGalvanized</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Dock</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_windows_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Windows_Dark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_roof'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>RoofCorrugated</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_wall'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Wall</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_branches'>
+          <geometry>
+            <mesh>
+              <uri>model://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>TreeDiffuse</name>
+              </submesh>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://sydney_regatta/materials/scripts/</uri>
+              <uri>model://sydney_regatta/materials/textures/</uri>
+              <name>SydneyTree/Branch</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta_shore.dae</uri>
+            </mesh>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_0'>
+      <static>1</static>
+      <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_1'>
+      <static>1</static>
+      <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_2'>
+      <static>1</static>
+      <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='antenna'>
+      <static>1</static>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://antenna/meshes/antenna.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.95 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.35</radius>
+              <length>1.9</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+    </model>
+    <model name='ground_station_0'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+    </model>
+    <model name='ground_station_1'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+    </model>
+    <model name='ground_station_2'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+    </model>
+    <model name='blue_projectile'>
+      <link name='link'>
+        <inertial>
+          <mass>0.04</mass>
+          <inertia>
+            <ixx>2.166e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2166</iyy>
+            <iyz>0</iyz>
+            <izz>2166</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://blue_projectile/materials/scripts/blue_projectile.material</uri>
+              <name>blue_projectile/Blue</name>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name='buoyancy_sphere'>
+          <link_name>link</link_name>
+          <pose>0 0 -0.02 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+      </plugin>
+      <pose>-545 60 0.03 0 -0 0</pose>
+    </model>
+    <model name='ocean_waves'>
+      <static>1</static>
+      <plugin name='ocean_waves::wavefield_entity' filename='libWavefieldModelPlugin.so'>
+        <static>0</static>
+        <update_rate>30</update_rate>
+        <size>1000 1000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>5</period>
+          <number>3</number>
+          <scale>2.5</scale>
+          <gain>0.1</gain>
+          <direction>1.0 0.0</direction>
+          <angle>0.4</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name='ocean_waves_link'>
+        <visual name='ocean_waves_visual'>
+          <plugin name='ocean_waves_visual_plugin' filename='libWavefieldVisualPlugin.so'>
+            <enableRtt>1</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>5</period>
+              <number>3</number>
+              <scale>2.5</scale>
+              <gain>0.1</gain>
+              <direction>1.0 0.0</direction>
+              <angle>0.4</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name='ocean_waves_below_visual'>
+          <pose>0 0 -0.05 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <plugin name='wind' filename='libusv_gazebo_wind_plugin.so'>
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector>.5 .5 .33</coeff_vector>
+      </wind_obj>
+      <wind_direction>270</wind_direction>
+      <wind_mean_velocity>0</wind_mean_velocity>
+      <var_wind_gain_constants>0</var_wind_gain_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
+      <random_seed/>
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <model name='robotx_light_buoy'>
+      <pose>-511 218 0.25 0 -0 3.14</pose>
+      <link name='base_link'>
+        <inertial>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <mass>67.15</mass>
+          <inertia>
+            <ixx>13.486</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>13.486</iyy>
+            <iyz>0</iyz>
+            <izz>25.1813</izz>
+          </inertia>
+        </inertial>
+        <visual name='base'>
+          <geometry>
+            <mesh>
+              <uri>file://robotx_light_buoy/mesh/robotx_light_buoy.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='panel_1'>
+          <pose>-0.05 0.09 1.3 0 -0 0.5</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+          <plugin name='lightplugin' filename='liblight_buoy_plugin.so'>
+            <color_1>off</color_1>
+            <color_2>off</color_2>
+            <color_3>off</color_3>
+            <visuals>
+              <visual>robotx_light_buoy::base_link::panel_1</visual>
+              <visual>robotx_light_buoy::base_link::panel_2</visual>
+              <visual>robotx_light_buoy::base_link::panel_3</visual>
+            </visuals>
+            <robot_namespace>vrx</robot_namespace>
+            <topic>light_buoy/shuffle</topic>
+          </plugin>
+        </visual>
+        <visual name='panel_2'>
+          <pose>-0.06 -0.085 1.3 0 0 -0.54719</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <visual name='panel_3'>
+          <pose>0.11 -0.003 1.3 0 -0 1.5472</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision_base'>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='collision_body'>
+          <pose>0 0 0.85 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.4</radius>
+              <length>1.75</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>1000.0</linear_drag>
+        <angular_drag>200.0</angular_drag>
+        <buoyancy name='buoyancy_base'>
+          <link_name>base_link</link_name>
+          <pose>0 0 -0.2 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <buoyancy name='buoyancy_body'>
+          <link_name>base_link</link_name>
+          <pose>0 0 0.8 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.15</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+      </plugin>
+    </model>
+    <plugin name='contain_placard1_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard1_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='scan_dock__deliver_scoring_plugin' filename='libscan_dock_scoring_plugin.so'>
+      <vehicle>wamv</vehicle>
+      <task_name>scan_dock_deliver</task_name>
+      <initial_state_duration>3</initial_state_duration>
+      <ready_state_duration>3</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <robot_namespace>vrx</robot_namespace>
+      <color_sequence_service>scan_dock_deliver/color_sequence</color_sequence_service>
+      <color_1>blue</color_1>
+      <color_2>green</color_2>
+      <color_3>red</color_3>
+      <dock_bonus_points>15</dock_bonus_points>
+      <correct_dock_bonus_points>5</correct_dock_bonus_points>
+      <bays>
+        <bay>
+          <name>bay1</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>red_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay2</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>1</dock_allowed>
+          <symbol>blue_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay3</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>yellow_rectangle</symbol>
+        </bay>
+      </bays>
+      <targets>
+        <target>
+          <topic>vrx/dock_2022_placard1_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard1_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+      </targets>
+    </plugin>
+    <plugin name='vehicle_docked_bay1' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay1_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+    <physics type='ode'>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+    </physics>
+    <wind/>
+    <model name='wamv'>
+      <link name='wamv/base_link'>
+        <inertial>
+          <pose>0.012722 0 0.026171 0 -0 0</pose>
+          <mass>182.806</mass>
+          <inertia>
+            <ixx>128.232</ixx>
+            <ixy>-2.4178e-21</ixy>
+            <ixz>-3.85993</ixz>
+            <iyy>403.15</iyy>
+            <iyz>-9.28107e-22</iyz>
+            <izz>447.942</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_collision_collision'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_collision_collision_1'>
+          <pose>0.95 0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_lens_collision_collision_2'>
+          <pose>0.987607 0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_box_collision_collision_3'>
+          <pose>0.949948 0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_collision_collision_4'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_collision_collision_5'>
+          <pose>0.95 -0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_lens_collision_collision_6'>
+          <pose>0.987607 -0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_box_collision_collision_7'>
+          <pose>0.949948 -0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_collision_collision_8'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_collision_collision_9'>
+          <pose>0.734 0 1.95 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_collision_collision_10'>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.075</length>
+              <radius>0.055</radius>
+            </cylinder>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <friction>
+              <ode/>
+              <torsional>
+                <ode/>
+              </torsional>
+            </friction>
+            <bounce/>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_float_collision_11'>
+          <pose>-0.4 1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_mid_float_collision_12'>
+          <pose>1.85 1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_front_float_collision_13'>
+          <pose>2.3 1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_lower_collision_14'>
+          <pose>0.9 0.85 1 0.78 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_upper_collision_15'>
+          <pose>0.9 0.6 1.18 1.35 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_lower_collision_16'>
+          <pose>-0.65 0.99 0.7 0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_medium_collision_17'>
+          <pose>-0.57 0.87 1.05 0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_upper_collision_18'>
+          <pose>-0.55 0.65 1.17 1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_lower_collision_19'>
+          <pose>-0.74 1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_medium_collision_20'>
+          <pose>-0.79 0.91 1.05 0.75 -0.15 -0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_upper_collision_21'>
+          <pose>-0.81 0.67 1.18 1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_joint_collision_22'>
+          <pose>0.58 1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_float_collision_23'>
+          <pose>-0.4 -1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_mid_float_collision_24'>
+          <pose>1.85 -1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_front_float_collision_25'>
+          <pose>2.3 -1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_lower_collision_26'>
+          <pose>0.9 -0.85 1 -0.78 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_upper_collision_27'>
+          <pose>0.9 -0.6 1.18 -1.35 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_lower_collision_28'>
+          <pose>-0.65 -0.99 0.7 -0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_medium_collision_29'>
+          <pose>-0.57 -0.87 1.05 -0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_upper_collision_30'>
+          <pose>-0.55 -0.65 1.17 -1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_lower_collision_31'>
+          <pose>-0.74 -1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_medium_collision_32'>
+          <pose>-0.79 -0.91 1.05 -0.75 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_upper_collision_33'>
+          <pose>-0.81 -0.67 1.18 -1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_joint_collision_34'>
+          <pose>0.58 -1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__top_base_collision_35'>
+          <pose>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.85 1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__hydrophones_collision_collision_36'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_left_cam_post_link_visual'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_visual_visual_1'>
+          <pose>0.912 0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_visual_visual_2'>
+          <pose>0.937721 0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_right_cam_post_link_visual_3'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_visual_visual_4'>
+          <pose>0.912 -0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_visual_visual_5'>
+          <pose>0.937721 -0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_link_visual_6'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_visual_visual_7'>
+          <pose>0.696 0 1.947 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_visual_visual_8'>
+          <pose>0.764941 0 1.96619 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/3d_lidar/mesh/3d_lidar.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/dummy_link_visual_9'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/WAM-V-Base/mesh/WAM-V-Base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/hydrophones_visual_10'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name='front_left_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_left_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_left_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_left_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_left_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='front_right_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_right_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_right_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_right_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_right_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 -0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='velodyne_sensor' type='gpu_ray'>
+          <update_rate>10</update_rate>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>18750</samples>
+                <resolution>0.1</resolution>
+                <min_angle>-3.14159</min_angle>
+                <max_angle>3.14159</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>16</samples>
+                <resolution>1</resolution>
+                <min_angle>-0.261799</min_angle>
+                <max_angle>0.261799</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>0.1</min>
+              <max>130</max>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.01</stddev>
+            </noise>
+          </ray>
+          <plugin name='velodyne_plugin' filename='libgazebo_ros_velodyne_gpu_laser.so'>
+            <topicName>velodyne_points</topicName>
+            <frameName>velodyne</frameName>
+            <min_intensity>0</min_intensity>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+        </sensor>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 1.1 0.318237 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_engine_link'>
+        <pose relative_to='BL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BL_engine_link</parent>
+        <child>BL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_propeller_link'>
+        <pose relative_to='BL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_propeller_link_fixed_joint_lump__BL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 -1.1 0.318237 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_engine_link'>
+        <pose relative_to='BR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BR_engine_link</parent>
+        <child>BR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_propeller_link'>
+        <pose relative_to='BR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_propeller_link_fixed_joint_lump__BR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 0.54 0.49675 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_engine_link'>
+        <pose relative_to='FL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FL_engine_link</parent>
+        <child>FL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_propeller_link'>
+        <pose relative_to='FL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_propeller_link_fixed_joint_lump__FL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 -0.54 0.49657 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_engine_link'>
+        <pose relative_to='FR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FR_engine_link</parent>
+        <child>FR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_propeller_link'>
+        <pose relative_to='FR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_propeller_link_fixed_joint_lump__FR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_base_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.54 0.3 1.3 0 -0 0.1</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ball_shooter_base_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_base_link'>
+        <pose relative_to='wamv/ball_shooter_base_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>-0.02 0 0.05 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00083</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00052083</iyy>
+            <iyz>0</iyz>
+            <izz>0.00052083</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/ball_shooter_base_link_fixed_joint_lump__ball_shooter_base_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_launcher_joint' type='revolute'>
+        <pose relative_to='wamv/ball_shooter_base_link'>-0.0204 0 0.107877 0 -0.8 0</pose>
+        <parent>wamv/ball_shooter_base_link</parent>
+        <child>wamv/ball_shooter_launcher_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_launcher_link'>
+        <pose relative_to='wamv/ball_shooter_launcher_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 3.14159 -1.57079 3.14159</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00177917</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00177917</iyy>
+            <iyz>0</iyz>
+            <izz>0.000225</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_collision_collision'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <box>
+              <size>0.3 0.3 0.2</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_launcher_visual_visual'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_launcher.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/imu_wamv_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/imu_wamv_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/imu_wamv_link'>
+        <pose relative_to='wamv/imu_wamv_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.1</mass>
+          <inertia>
+            <ixx>8.3e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>8.3e-05</iyy>
+            <iyz>0</iyz>
+            <izz>0.0125</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/imu_wamv_link_fixed_joint_lump__imu_wamv_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.05 0.025 0.005</size>
+            </box>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ins_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ins_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ins_link'>
+        <pose relative_to='wamv/ins_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.006458</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.006458</iyy>
+            <iyz>0</iyz>
+            <izz>0.01125</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_base_collision'>
+          <pose>0 0 0.025 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.05</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_antenna_collision_1'>
+          <pose>0 0 0.11 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.15</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ins_link_fixed_joint_lump__ins_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_gazebo/models/gps/mesh/gps.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='gps_plugin_ins' filename='libhector_gazebo_ros_gps.so'>
+        <updateRate>15</updateRate>
+        <alwaysOn>1</alwaysOn>
+        <bodyName>wamv/ins_link</bodyName>
+        <frameId>wamv/ins_link</frameId>
+        <topicName>wamv/sensors/gps/gps/fix</topicName>
+        <velocityTopicName>wamv/sensors/gps/gps/fix_velocity</velocityTopicName>
+        <useWorldSphericalCoordinates>1</useWorldSphericalCoordinates>
+        <offset>0.0 0.0 0.0</offset>
+        <drift>0.0 0.0 0.0</drift>
+        <gaussianNoise>0 0 0</gaussianNoise>
+        <velocityOffset>0.0 0.0 0.0</velocityOffset>
+        <velocityDrift>0.0 0.0 0.0</velocityDrift>
+        <velocityGaussianNoise>0.0 0.0 0.0</velocityGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='imu_plugin_imu_wamv' filename='libhector_gazebo_ros_imu.so'>
+        <updateRate>15</updateRate>
+        <bodyName>wamv/imu_wamv_link</bodyName>
+        <topicName>wamv/sensors/imu/imu/data</topicName>
+        <serviceName>wamv/sensors/imu_service</serviceName>
+        <frameId>wamv/imu_wamv_link</frameId>
+        <alwaysOn>1</alwaysOn>
+        <accelOffset>0.0 0.0 0.0</accelOffset>
+        <accelDrift>0.0 0.0 0.0</accelDrift>
+        <accelDriftFrequency>0.00027 0.00027 0.000027</accelDriftFrequency>
+        <accelGaussianNoise>0.0 0.0 0.0</accelGaussianNoise>
+        <rateOffset>0.0 0.0 0.0</rateOffset>
+        <rateDrift>0.0 0.0 0.0</rateDrift>
+        <rateDriftFrequency>0.00027 0.00027 0.000027</rateDriftFrequency>
+        <rateGaussianNoise>0.0 0.0 0.0</rateGaussianNoise>
+        <yawOffset>0.0</yawOffset>
+        <yawDrift>0.0</yawDrift>
+        <yawDriftFrequency>0.00027</yawDriftFrequency>
+        <yawGaussianNoise>0.0</yawGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='ball_shooter_plugin' filename='libball_shooter_plugin.so'>
+        <projectile>
+          <model_name>blue_projectile</model_name>
+          <link_name>link</link_name>
+          <frame>wamv/ball_shooter_launcher_link</frame>
+          <pose>0.14 0 0 0 0 0</pose>
+        </projectile>
+        <num_shots>4</num_shots>
+        <shot_force>300</shot_force>
+        <topic>wamv/shooters/ball_shooter/fire</topic>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='pinger_plugin' filename='libusv_gazebo_acoustic_pinger_plugin.so'>
+        <frameId>wamv/pinger</frameId>
+        <topicName>wamv/sensors/pingers/hydrophones/range_bearing</topicName>
+        <setPositionTopicName>wamv/sensors/pingers/hydrophones/set_pinger_position</setPositionTopicName>
+        <rangeNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>3.0</stddev>
+          </noise>
+        </rangeNoise>
+        <bearingNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </bearingNoise>
+        <elevationNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </elevationNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='wamv_gazebo_thrust' filename='libusv_gazebo_thrust_plugin.so'>
+        <cmdTimeout>1.0</cmdTimeout>
+        <robotNamespace>wamv</robotNamespace>
+        <thruster>
+          <linkName>BL_propeller_link</linkName>
+          <propJointName>BL_engine_propeller_joint</propJointName>
+          <engineJointName>BL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>BR_propeller_link</linkName>
+          <propJointName>BR_engine_propeller_joint</propJointName>
+          <engineJointName>BR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FL_propeller_link</linkName>
+          <propJointName>FL_engine_propeller_joint</propJointName>
+          <engineJointName>FL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FR_propeller_link</linkName>
+          <propJointName>FR_engine_propeller_joint</propJointName>
+          <engineJointName>FR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+      </plugin>
+      <plugin name='usv_dynamics_wamv_dynamics_plugin' filename='libusv_gazebo_dynamics_plugin.so'>
+        <bodyName>wamv/base_link</bodyName>
+        <waterLevel>0</waterLevel>
+        <waterDensity>997.8</waterDensity>
+        <xDotU>0.0</xDotU>
+        <yDotV>0.0</yDotV>
+        <nDotR>0.0</nDotR>
+        <xU>51.3</xU>
+        <xUU>72.4</xUU>
+        <yV>40.0</yV>
+        <yVV>0.0</yVV>
+        <zW>500.0</zW>
+        <kP>50.0</kP>
+        <mQ>50.0</mQ>
+        <nR>400.0</nR>
+        <nRR>0.0</nRR>
+        <hullRadius>0.213</hullRadius>
+        <boatWidth>2.4</boatWidth>
+        <boatLength>4.9</boatLength>
+        <length_n>2</length_n>
+        <wave_model>ocean_waves</wave_model>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <frame name='wamv/front_left_cam_to_front_left_cam_link_optical_joint' attached_to='wamv/front_left_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link_optical' attached_to='wamv/front_left_cam_to_front_left_cam_link_optical_joint'/>
+      <frame name='wamv/front_left_cam_post_arm_to_front_left_cam_joint' attached_to='wamv/front_left_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link' attached_to='wamv/front_left_cam_post_arm_to_front_left_cam_joint'/>
+      <frame name='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint' attached_to='wamv/front_left_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_arm_link' attached_to='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_left_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_link' attached_to='wamv/base_to_front_left_cam_post_joint'/>
+      <frame name='wamv/front_right_cam_to_front_right_cam_link_optical_joint' attached_to='wamv/front_right_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link_optical' attached_to='wamv/front_right_cam_to_front_right_cam_link_optical_joint'/>
+      <frame name='wamv/front_right_cam_post_arm_to_front_right_cam_joint' attached_to='wamv/front_right_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link' attached_to='wamv/front_right_cam_post_arm_to_front_right_cam_joint'/>
+      <frame name='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint' attached_to='wamv/front_right_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_arm_link' attached_to='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_right_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_link' attached_to='wamv/base_to_front_right_cam_post_joint'/>
+      <frame name='wamv/velodyne_post_arm_to_velodyne_joint' attached_to='velodyne_post_arm_link'>
+        <pose>0.04 0 0.05 0 0.261799 0</pose>
+      </frame>
+      <frame name='velodyne' attached_to='wamv/velodyne_post_arm_to_velodyne_joint'/>
+      <frame name='wamv/velodyne_post_to_velodyne_post_arm_joint' attached_to='velodyne_post_link'>
+        <pose>0.03 0 0.32675 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_arm_link' attached_to='wamv/velodyne_post_to_velodyne_post_arm_joint'/>
+      <frame name='wamv/base_to_velodyne_post_joint' attached_to='wamv/base_link'>
+        <pose>0.704 0 1.62325 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_link' attached_to='wamv/base_to_velodyne_post_joint'/>
+      <frame name='wamv/dummy_joint' attached_to='wamv/base_link'>
+        <pose>0 0 0 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/dummy_link' attached_to='wamv/dummy_joint'/>
+      <frame name='wamv/hydrophones_pinger_joint' attached_to='wamv/base_link'>
+        <pose>1 0 -1 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/hydrophones' attached_to='wamv/hydrophones_pinger_joint'/>
+      <pose>-532 162 0.1 0 -0 1</pose>
+    </model>
+    <state world_name='vrx_scan_dock_deliver'>
+      <sim_time>67 734000000</sim_time>
+      <real_time>142 63531314</real_time>
+      <wall_time>1725827192 3236931</wall_time>
+      <iterations>67734</iterations>
+      <model name='antenna'>
+        <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='blue_projectile'>
+        <pose>-545 60 -0.028178 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-545 60 -0.028178 0 -0 0</pose>
+          <velocity>0 0 0.023264 0 -0 0</velocity>
+          <acceleration>0 0 0.152208 0 -0 0</acceleration>
+          <wrench>0 0 0.006088 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_0'>
+        <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-540.743 146.687 1.66777 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-539.972 146.474 1.67444 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-541.727 146.128 1.67569 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-541.531 147.215 1.6548 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-540.049 147.325 1.65735 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_1'>
+        <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-537.569 146.021 1.6782 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-536.798 145.808 1.68302 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-538.553 145.462 1.68831 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-538.357 146.549 1.66717 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-536.875 146.659 1.66628 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_2'>
+        <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-534.497 145.103 1.71632 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-533.726 144.89 1.72031 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-535.481 144.545 1.72896 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-535.285 145.632 1.70558 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-533.803 145.741 1.70217 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ocean_waves'>
+        <pose>1.26646 -4.11833 0 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='ocean_waves_link'>
+          <pose>1.26646 -4.11833 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_0'>
+        <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_1'>
+        <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_2'>
+        <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='robotx_light_buoy'>
+        <pose>-527.322 168.543 0.412864 0 -0 3.14</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-527.322 168.543 0.412864 0 -0 3.14</pose>
+          <velocity>0 0 -0.052451 0 -0 0</velocity>
+          <acceleration>0 0 -0.095383 0 -0 0</acceleration>
+          <wrench>0 0 -6.40499 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='sydneyregatta'>
+        <pose>0 0 0.2 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>0 0 0.2 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='wamv'>
+        <pose>-532.054 162.134 -0.084124 -0.00824 -0.012462 1</pose>
+        <scale>1 1 1</scale>
+        <link name='BL_engine_link'>
+          <pose>-534.027 161.102 0.200959 -0.014638 -0.002986 1.78532</pose>
+          <velocity>-0.001205 0.001857 -0.059425 -0.001444 0.001062 9.9e-05</velocity>
+          <acceleration>0.012249 0.007351 0.208086 -0.057246 0.083765 0.003922</acceleration>
+          <wrench>0.183739 0.110262 3.1213 0 -0 0</wrench>
+        </link>
+        <link name='BL_propeller_link'>
+          <pose>-533.961 160.834 -0.309186 -0.014638 -0.002986 1.78532</pose>
+          <velocity>-0.00172 0.001127 -0.059108 -0.001444 0.001062 9.9e-05</velocity>
+          <acceleration>-0.028552 -0.02353 0.219061 -0.060641 0.08046 0.000761</acceleration>
+          <wrench>-0.014276 -0.011765 0.109531 0 -0 0</wrench>
+        </link>
+        <link name='BR_engine_link'>
+          <pose>-532.176 159.914 0.219086 0.002986 -0.014638 0.214537</pose>
+          <velocity>-0.001071 0.002062 -0.059675 -0.001443 0.001062 7.4e-05</velocity>
+          <acceleration>0.014651 0.009919 0.131259 -0.060535 0.080081 0.004338</acceleration>
+          <wrench>0.219769 0.148792 1.96889 0 -0 0</wrench>
+        </link>
+        <link name='BR_propeller_link'>
+          <pose>-532.44 159.857 -0.2943 0.002986 -0.014638 0.214537</pose>
+          <velocity>-0.001612 0.001302 -0.059313 -0.001443 0.001062 7.4e-05</velocity>
+          <acceleration>-0.026605 -0.021443 0.155969 -0.060641 0.08046 0.000712</acceleration>
+          <wrench>-0.013303 -0.010721 0.077985 0 -0 0</wrench>
+        </link>
+        <link name='FL_engine_link'>
+          <pose>-531.726 163.651 0.426315 0.002986 -0.014638 0.21454</pose>
+          <velocity>-0.001212 0.002405 -0.065548 -0.001444 0.001062 9e-05</velocity>
+          <acceleration>0.028351 0.022837 -0.131597 -0.060733 0.079993 0.004256</acceleration>
+          <wrench>0.42527 0.342556 -1.97395 0 -0 0</wrench>
+        </link>
+        <link name='FL_propeller_link'>
+          <pose>-531.991 163.595 -0.087071 0.002986 -0.014638 0.21454</pose>
+          <velocity>-0.001753 0.00164 -0.065186 -0.001444 0.001062 9e-05</velocity>
+          <acceleration>-0.012912 -0.008494 -0.106886 -0.060641 0.08046 0.000596</acceleration>
+          <wrench>-0.006456 -0.004247 -0.053443 0 -0 0</wrench>
+        </link>
+        <link name='FR_engine_link'>
+          <pose>-530.818 163.068 0.435033 -0.014638 -0.002986 1.78531</pose>
+          <velocity>-0.001147 0.002506 -0.065671 -0.001443 0.001062 8.6e-05</velocity>
+          <acceleration>0.029516 0.024087 -0.169312 -0.056924 0.083913 0.004017</acceleration>
+          <wrench>0.442741 0.361307 -2.53968 0 -0 0</wrench>
+        </link>
+        <link name='FR_propeller_link'>
+          <pose>-530.751 162.799 -0.075111 -0.014638 -0.002986 1.78531</pose>
+          <velocity>-0.001665 0.001775 -0.065353 -0.001443 0.001062 8.6e-05</velocity>
+          <acceleration>-0.011244 -0.006785 -0.158337 -0.060642 0.08046 0.000913</acceleration>
+          <wrench>-0.005622 -0.003393 -0.079168 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_base_link'>
+          <pose>-532.032 162.743 1.21999 -0.009443 -0.011577 1.1</pose>
+          <velocity>-0.000282 0.003521 -0.063911 -0.001444 0.001062 0.0001</velocity>
+          <acceleration>0.097014 0.07371 -0.04998 -0.10144 0.071187 0.004375</acceleration>
+          <wrench>0.048507 0.036855 -0.02499 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_launcher_link'>
+          <pose>-532.043 162.724 1.32762 -0.013717 -0.81153 1.10984</pose>
+          <velocity>-0.000165 0.003676 -0.063873 -0.001444 0.001062 0.0001</velocity>
+          <acceleration>0.101672 0.077218 -0.049859 0.099135 0.295499 0.257516</acceleration>
+          <wrench>0.050836 0.038609 -0.024929 0 -0 0</wrench>
+        </link>
+        <link name='wamv/base_link'>
+          <pose>-532.054 162.134 -0.084124 -0.00824 -0.012462 1</pose>
+          <velocity>-0.001608 0.001636 -0.06301 -0.001444 0.001062 9.7e-05</velocity>
+          <acceleration>-0.0094 -0.006776 -0.014377 -0.489693 -0.254024 -0.011926</acceleration>
+          <wrench>-1.71837 -1.23871 -2.62817 0 -0 0</wrench>
+        </link>
+        <link name='wamv/imu_wamv_link'>
+          <pose>-532.088 162.419 1.4173 -0.00824 -0.012462 1</pose>
+          <velocity>-4.1e-05 0.003801 -0.063385 -0.001444 0.001062 9.7e-05</velocity>
+          <acceleration>0.109062 0.082656 -0.027762 -0.059038 0.081152 0.00048</acceleration>
+          <wrench>0.010906 0.008266 -0.002776 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ins_link'>
+          <pose>-532.088 162.419 1.4173 -0.00824 -0.012462 1</pose>
+          <velocity>-4.1e-05 0.003801 -0.063385 -0.001444 0.001062 9.7e-05</velocity>
+          <acceleration>0.109062 0.082656 -0.027762 -0.06064 0.080461 0.000648</acceleration>
+          <wrench>0.109062 0.082656 -0.027762 0 -0 0</wrench>
+        </link>
+      </model>
+      <light name='sun'>
+        <pose>0 0 10 0 -0 0</pose>
+      </light>
+    </state>
+  </world>
+</sdf>

--- a/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/left.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/left.world
@@ -1,0 +1,3970 @@
+<sdf version='1.7'>
+  <world name='vrx_scan_dock_deliver'>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>1</shadows>
+    </scene>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.7242</latitude_deg>
+      <longitude_deg>150.68</longitude_deg>
+      <elevation>0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+    <light name='sun' type='directional'>
+      <cast_shadows>1</cast_shadows>
+      <pose>0 0 10 0 -0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>-453.391 179.995 23.1197 0 0.248344 2.93686</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+    <model name='sydneyregatta'>
+      <pose>0 0 0.2 0 -0 0</pose>
+      <static>1</static>
+      <link name='link'>
+        <visual name='visual_terrain'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Terrain</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_concrete'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>ConcreteDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>DockDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_metal_galvanized'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>MetalGalvanized</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Dock</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_windows_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Windows_Dark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_roof'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>RoofCorrugated</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_wall'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Wall</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_branches'>
+          <geometry>
+            <mesh>
+              <uri>model://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>TreeDiffuse</name>
+              </submesh>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://sydney_regatta/materials/scripts/</uri>
+              <uri>model://sydney_regatta/materials/textures/</uri>
+              <name>SydneyTree/Branch</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta_shore.dae</uri>
+            </mesh>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_0'>
+      <static>1</static>
+      <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_1'>
+      <static>1</static>
+      <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_2'>
+      <static>1</static>
+      <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='antenna'>
+      <static>1</static>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://antenna/meshes/antenna.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.95 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.35</radius>
+              <length>1.9</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+    </model>
+    <model name='ground_station_0'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+    </model>
+    <model name='ground_station_1'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+    </model>
+    <model name='ground_station_2'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+    </model>
+    <model name='blue_projectile'>
+      <link name='link'>
+        <inertial>
+          <mass>0.04</mass>
+          <inertia>
+            <ixx>2.166e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2166</iyy>
+            <iyz>0</iyz>
+            <izz>2166</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://blue_projectile/materials/scripts/blue_projectile.material</uri>
+              <name>blue_projectile/Blue</name>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name='buoyancy_sphere'>
+          <link_name>link</link_name>
+          <pose>0 0 -0.02 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+      </plugin>
+      <pose>-545 60 0.03 0 -0 0</pose>
+    </model>
+    <model name='ocean_waves'>
+      <static>1</static>
+      <plugin name='ocean_waves::wavefield_entity' filename='libWavefieldModelPlugin.so'>
+        <static>0</static>
+        <update_rate>30</update_rate>
+        <size>1000 1000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>5</period>
+          <number>3</number>
+          <scale>2.5</scale>
+          <gain>0.1</gain>
+          <direction>1.0 0.0</direction>
+          <angle>0.4</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name='ocean_waves_link'>
+        <visual name='ocean_waves_visual'>
+          <plugin name='ocean_waves_visual_plugin' filename='libWavefieldVisualPlugin.so'>
+            <enableRtt>1</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>5</period>
+              <number>3</number>
+              <scale>2.5</scale>
+              <gain>0.1</gain>
+              <direction>1.0 0.0</direction>
+              <angle>0.4</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name='ocean_waves_below_visual'>
+          <pose>0 0 -0.05 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <plugin name='wind' filename='libusv_gazebo_wind_plugin.so'>
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector>.5 .5 .33</coeff_vector>
+      </wind_obj>
+      <wind_direction>270</wind_direction>
+      <wind_mean_velocity>0</wind_mean_velocity>
+      <var_wind_gain_constants>0</var_wind_gain_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
+      <random_seed/>
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <model name='robotx_light_buoy'>
+      <pose>-511 218 0.25 0 -0 3.14</pose>
+      <link name='base_link'>
+        <inertial>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <mass>67.15</mass>
+          <inertia>
+            <ixx>13.486</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>13.486</iyy>
+            <iyz>0</iyz>
+            <izz>25.1813</izz>
+          </inertia>
+        </inertial>
+        <visual name='base'>
+          <geometry>
+            <mesh>
+              <uri>file://robotx_light_buoy/mesh/robotx_light_buoy.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='panel_1'>
+          <pose>-0.05 0.09 1.3 0 -0 0.5</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+          <plugin name='lightplugin' filename='liblight_buoy_plugin.so'>
+            <color_1>off</color_1>
+            <color_2>off</color_2>
+            <color_3>off</color_3>
+            <visuals>
+              <visual>robotx_light_buoy::base_link::panel_1</visual>
+              <visual>robotx_light_buoy::base_link::panel_2</visual>
+              <visual>robotx_light_buoy::base_link::panel_3</visual>
+            </visuals>
+            <robot_namespace>vrx</robot_namespace>
+            <topic>light_buoy/shuffle</topic>
+          </plugin>
+        </visual>
+        <visual name='panel_2'>
+          <pose>-0.06 -0.085 1.3 0 0 -0.54719</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <visual name='panel_3'>
+          <pose>0.11 -0.003 1.3 0 -0 1.5472</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision_base'>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='collision_body'>
+          <pose>0 0 0.85 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.4</radius>
+              <length>1.75</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>1000.0</linear_drag>
+        <angular_drag>200.0</angular_drag>
+        <buoyancy name='buoyancy_base'>
+          <link_name>base_link</link_name>
+          <pose>0 0 -0.2 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <buoyancy name='buoyancy_body'>
+          <link_name>base_link</link_name>
+          <pose>0 0 0.8 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.15</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+      </plugin>
+    </model>
+    <plugin name='contain_placard1_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard1_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='scan_dock__deliver_scoring_plugin' filename='libscan_dock_scoring_plugin.so'>
+      <vehicle>wamv</vehicle>
+      <task_name>scan_dock_deliver</task_name>
+      <initial_state_duration>3</initial_state_duration>
+      <ready_state_duration>3</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <robot_namespace>vrx</robot_namespace>
+      <color_sequence_service>scan_dock_deliver/color_sequence</color_sequence_service>
+      <color_1>blue</color_1>
+      <color_2>green</color_2>
+      <color_3>red</color_3>
+      <dock_bonus_points>15</dock_bonus_points>
+      <correct_dock_bonus_points>5</correct_dock_bonus_points>
+      <bays>
+        <bay>
+          <name>bay1</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>red_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay2</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>1</dock_allowed>
+          <symbol>blue_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay3</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>yellow_rectangle</symbol>
+        </bay>
+      </bays>
+      <targets>
+        <target>
+          <topic>vrx/dock_2022_placard1_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard1_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+      </targets>
+    </plugin>
+    <plugin name='vehicle_docked_bay1' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay1_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+    <physics type='ode'>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+    </physics>
+    <wind/>
+    <model name='wamv'>
+      <link name='wamv/base_link'>
+        <inertial>
+          <pose>0.012722 0 0.026171 0 -0 0</pose>
+          <mass>182.806</mass>
+          <inertia>
+            <ixx>128.232</ixx>
+            <ixy>-2.4178e-21</ixy>
+            <ixz>-3.85993</ixz>
+            <iyy>403.15</iyy>
+            <iyz>-9.28107e-22</iyz>
+            <izz>447.942</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_collision_collision'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_collision_collision_1'>
+          <pose>0.95 0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_lens_collision_collision_2'>
+          <pose>0.987607 0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_box_collision_collision_3'>
+          <pose>0.949948 0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_collision_collision_4'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_collision_collision_5'>
+          <pose>0.95 -0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_lens_collision_collision_6'>
+          <pose>0.987607 -0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_box_collision_collision_7'>
+          <pose>0.949948 -0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_collision_collision_8'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_collision_collision_9'>
+          <pose>0.734 0 1.95 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_collision_collision_10'>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.075</length>
+              <radius>0.055</radius>
+            </cylinder>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <friction>
+              <ode/>
+              <torsional>
+                <ode/>
+              </torsional>
+            </friction>
+            <bounce/>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_float_collision_11'>
+          <pose>-0.4 1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_mid_float_collision_12'>
+          <pose>1.85 1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_front_float_collision_13'>
+          <pose>2.3 1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_lower_collision_14'>
+          <pose>0.9 0.85 1 0.78 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_upper_collision_15'>
+          <pose>0.9 0.6 1.18 1.35 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_lower_collision_16'>
+          <pose>-0.65 0.99 0.7 0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_medium_collision_17'>
+          <pose>-0.57 0.87 1.05 0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_upper_collision_18'>
+          <pose>-0.55 0.65 1.17 1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_lower_collision_19'>
+          <pose>-0.74 1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_medium_collision_20'>
+          <pose>-0.79 0.91 1.05 0.75 -0.15 -0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_upper_collision_21'>
+          <pose>-0.81 0.67 1.18 1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_joint_collision_22'>
+          <pose>0.58 1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_float_collision_23'>
+          <pose>-0.4 -1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_mid_float_collision_24'>
+          <pose>1.85 -1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_front_float_collision_25'>
+          <pose>2.3 -1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_lower_collision_26'>
+          <pose>0.9 -0.85 1 -0.78 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_upper_collision_27'>
+          <pose>0.9 -0.6 1.18 -1.35 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_lower_collision_28'>
+          <pose>-0.65 -0.99 0.7 -0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_medium_collision_29'>
+          <pose>-0.57 -0.87 1.05 -0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_upper_collision_30'>
+          <pose>-0.55 -0.65 1.17 -1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_lower_collision_31'>
+          <pose>-0.74 -1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_medium_collision_32'>
+          <pose>-0.79 -0.91 1.05 -0.75 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_upper_collision_33'>
+          <pose>-0.81 -0.67 1.18 -1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_joint_collision_34'>
+          <pose>0.58 -1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__top_base_collision_35'>
+          <pose>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.85 1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__hydrophones_collision_collision_36'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_left_cam_post_link_visual'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_visual_visual_1'>
+          <pose>0.912 0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_visual_visual_2'>
+          <pose>0.937721 0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_right_cam_post_link_visual_3'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_visual_visual_4'>
+          <pose>0.912 -0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_visual_visual_5'>
+          <pose>0.937721 -0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_link_visual_6'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_visual_visual_7'>
+          <pose>0.696 0 1.947 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_visual_visual_8'>
+          <pose>0.764941 0 1.96619 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/3d_lidar/mesh/3d_lidar.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/dummy_link_visual_9'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/WAM-V-Base/mesh/WAM-V-Base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/hydrophones_visual_10'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name='front_left_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_left_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_left_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_left_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_left_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='front_right_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_right_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_right_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_right_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_right_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 -0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='velodyne_sensor' type='gpu_ray'>
+          <update_rate>10</update_rate>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>18750</samples>
+                <resolution>0.1</resolution>
+                <min_angle>-3.14159</min_angle>
+                <max_angle>3.14159</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>16</samples>
+                <resolution>1</resolution>
+                <min_angle>-0.261799</min_angle>
+                <max_angle>0.261799</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>0.1</min>
+              <max>130</max>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.01</stddev>
+            </noise>
+          </ray>
+          <plugin name='velodyne_plugin' filename='libgazebo_ros_velodyne_gpu_laser.so'>
+            <topicName>velodyne_points</topicName>
+            <frameName>velodyne</frameName>
+            <min_intensity>0</min_intensity>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+        </sensor>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 1.1 0.318237 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_engine_link'>
+        <pose relative_to='BL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BL_engine_link</parent>
+        <child>BL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_propeller_link'>
+        <pose relative_to='BL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_propeller_link_fixed_joint_lump__BL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 -1.1 0.318237 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_engine_link'>
+        <pose relative_to='BR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BR_engine_link</parent>
+        <child>BR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_propeller_link'>
+        <pose relative_to='BR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_propeller_link_fixed_joint_lump__BR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 0.54 0.49675 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_engine_link'>
+        <pose relative_to='FL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FL_engine_link</parent>
+        <child>FL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_propeller_link'>
+        <pose relative_to='FL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_propeller_link_fixed_joint_lump__FL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 -0.54 0.49657 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_engine_link'>
+        <pose relative_to='FR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FR_engine_link</parent>
+        <child>FR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_propeller_link'>
+        <pose relative_to='FR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_propeller_link_fixed_joint_lump__FR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_base_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.54 0.3 1.3 0 -0 0.1</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ball_shooter_base_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_base_link'>
+        <pose relative_to='wamv/ball_shooter_base_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>-0.02 0 0.05 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00083</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00052083</iyy>
+            <iyz>0</iyz>
+            <izz>0.00052083</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/ball_shooter_base_link_fixed_joint_lump__ball_shooter_base_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_launcher_joint' type='revolute'>
+        <pose relative_to='wamv/ball_shooter_base_link'>-0.0204 0 0.107877 0 -0.8 0</pose>
+        <parent>wamv/ball_shooter_base_link</parent>
+        <child>wamv/ball_shooter_launcher_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_launcher_link'>
+        <pose relative_to='wamv/ball_shooter_launcher_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 3.14159 -1.57079 3.14159</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00177917</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00177917</iyy>
+            <iyz>0</iyz>
+            <izz>0.000225</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_collision_collision'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <box>
+              <size>0.3 0.3 0.2</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_launcher_visual_visual'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_launcher.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/imu_wamv_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/imu_wamv_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/imu_wamv_link'>
+        <pose relative_to='wamv/imu_wamv_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.1</mass>
+          <inertia>
+            <ixx>8.3e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>8.3e-05</iyy>
+            <iyz>0</iyz>
+            <izz>0.0125</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/imu_wamv_link_fixed_joint_lump__imu_wamv_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.05 0.025 0.005</size>
+            </box>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ins_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ins_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ins_link'>
+        <pose relative_to='wamv/ins_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.006458</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.006458</iyy>
+            <iyz>0</iyz>
+            <izz>0.01125</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_base_collision'>
+          <pose>0 0 0.025 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.05</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_antenna_collision_1'>
+          <pose>0 0 0.11 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.15</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ins_link_fixed_joint_lump__ins_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_gazebo/models/gps/mesh/gps.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='gps_plugin_ins' filename='libhector_gazebo_ros_gps.so'>
+        <updateRate>15</updateRate>
+        <alwaysOn>1</alwaysOn>
+        <bodyName>wamv/ins_link</bodyName>
+        <frameId>wamv/ins_link</frameId>
+        <topicName>wamv/sensors/gps/gps/fix</topicName>
+        <velocityTopicName>wamv/sensors/gps/gps/fix_velocity</velocityTopicName>
+        <useWorldSphericalCoordinates>1</useWorldSphericalCoordinates>
+        <offset>0.0 0.0 0.0</offset>
+        <drift>0.0 0.0 0.0</drift>
+        <gaussianNoise>0 0 0</gaussianNoise>
+        <velocityOffset>0.0 0.0 0.0</velocityOffset>
+        <velocityDrift>0.0 0.0 0.0</velocityDrift>
+        <velocityGaussianNoise>0.0 0.0 0.0</velocityGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='imu_plugin_imu_wamv' filename='libhector_gazebo_ros_imu.so'>
+        <updateRate>15</updateRate>
+        <bodyName>wamv/imu_wamv_link</bodyName>
+        <topicName>wamv/sensors/imu/imu/data</topicName>
+        <serviceName>wamv/sensors/imu_service</serviceName>
+        <frameId>wamv/imu_wamv_link</frameId>
+        <alwaysOn>1</alwaysOn>
+        <accelOffset>0.0 0.0 0.0</accelOffset>
+        <accelDrift>0.0 0.0 0.0</accelDrift>
+        <accelDriftFrequency>0.00027 0.00027 0.000027</accelDriftFrequency>
+        <accelGaussianNoise>0.0 0.0 0.0</accelGaussianNoise>
+        <rateOffset>0.0 0.0 0.0</rateOffset>
+        <rateDrift>0.0 0.0 0.0</rateDrift>
+        <rateDriftFrequency>0.00027 0.00027 0.000027</rateDriftFrequency>
+        <rateGaussianNoise>0.0 0.0 0.0</rateGaussianNoise>
+        <yawOffset>0.0</yawOffset>
+        <yawDrift>0.0</yawDrift>
+        <yawDriftFrequency>0.00027</yawDriftFrequency>
+        <yawGaussianNoise>0.0</yawGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='ball_shooter_plugin' filename='libball_shooter_plugin.so'>
+        <projectile>
+          <model_name>blue_projectile</model_name>
+          <link_name>link</link_name>
+          <frame>wamv/ball_shooter_launcher_link</frame>
+          <pose>0.14 0 0 0 0 0</pose>
+        </projectile>
+        <num_shots>4</num_shots>
+        <shot_force>300</shot_force>
+        <topic>wamv/shooters/ball_shooter/fire</topic>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='pinger_plugin' filename='libusv_gazebo_acoustic_pinger_plugin.so'>
+        <frameId>wamv/pinger</frameId>
+        <topicName>wamv/sensors/pingers/hydrophones/range_bearing</topicName>
+        <setPositionTopicName>wamv/sensors/pingers/hydrophones/set_pinger_position</setPositionTopicName>
+        <rangeNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>3.0</stddev>
+          </noise>
+        </rangeNoise>
+        <bearingNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </bearingNoise>
+        <elevationNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </elevationNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='wamv_gazebo_thrust' filename='libusv_gazebo_thrust_plugin.so'>
+        <cmdTimeout>1.0</cmdTimeout>
+        <robotNamespace>wamv</robotNamespace>
+        <thruster>
+          <linkName>BL_propeller_link</linkName>
+          <propJointName>BL_engine_propeller_joint</propJointName>
+          <engineJointName>BL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>BR_propeller_link</linkName>
+          <propJointName>BR_engine_propeller_joint</propJointName>
+          <engineJointName>BR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FL_propeller_link</linkName>
+          <propJointName>FL_engine_propeller_joint</propJointName>
+          <engineJointName>FL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FR_propeller_link</linkName>
+          <propJointName>FR_engine_propeller_joint</propJointName>
+          <engineJointName>FR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+      </plugin>
+      <plugin name='usv_dynamics_wamv_dynamics_plugin' filename='libusv_gazebo_dynamics_plugin.so'>
+        <bodyName>wamv/base_link</bodyName>
+        <waterLevel>0</waterLevel>
+        <waterDensity>997.8</waterDensity>
+        <xDotU>0.0</xDotU>
+        <yDotV>0.0</yDotV>
+        <nDotR>0.0</nDotR>
+        <xU>51.3</xU>
+        <xUU>72.4</xUU>
+        <yV>40.0</yV>
+        <yVV>0.0</yVV>
+        <zW>500.0</zW>
+        <kP>50.0</kP>
+        <mQ>50.0</mQ>
+        <nR>400.0</nR>
+        <nRR>0.0</nRR>
+        <hullRadius>0.213</hullRadius>
+        <boatWidth>2.4</boatWidth>
+        <boatLength>4.9</boatLength>
+        <length_n>2</length_n>
+        <wave_model>ocean_waves</wave_model>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <frame name='wamv/front_left_cam_to_front_left_cam_link_optical_joint' attached_to='wamv/front_left_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link_optical' attached_to='wamv/front_left_cam_to_front_left_cam_link_optical_joint'/>
+      <frame name='wamv/front_left_cam_post_arm_to_front_left_cam_joint' attached_to='wamv/front_left_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link' attached_to='wamv/front_left_cam_post_arm_to_front_left_cam_joint'/>
+      <frame name='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint' attached_to='wamv/front_left_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_arm_link' attached_to='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_left_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_link' attached_to='wamv/base_to_front_left_cam_post_joint'/>
+      <frame name='wamv/front_right_cam_to_front_right_cam_link_optical_joint' attached_to='wamv/front_right_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link_optical' attached_to='wamv/front_right_cam_to_front_right_cam_link_optical_joint'/>
+      <frame name='wamv/front_right_cam_post_arm_to_front_right_cam_joint' attached_to='wamv/front_right_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link' attached_to='wamv/front_right_cam_post_arm_to_front_right_cam_joint'/>
+      <frame name='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint' attached_to='wamv/front_right_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_arm_link' attached_to='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_right_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_link' attached_to='wamv/base_to_front_right_cam_post_joint'/>
+      <frame name='wamv/velodyne_post_arm_to_velodyne_joint' attached_to='velodyne_post_arm_link'>
+        <pose>0.04 0 0.05 0 0.261799 0</pose>
+      </frame>
+      <frame name='velodyne' attached_to='wamv/velodyne_post_arm_to_velodyne_joint'/>
+      <frame name='wamv/velodyne_post_to_velodyne_post_arm_joint' attached_to='velodyne_post_link'>
+        <pose>0.03 0 0.32675 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_arm_link' attached_to='wamv/velodyne_post_to_velodyne_post_arm_joint'/>
+      <frame name='wamv/base_to_velodyne_post_joint' attached_to='wamv/base_link'>
+        <pose>0.704 0 1.62325 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_link' attached_to='wamv/base_to_velodyne_post_joint'/>
+      <frame name='wamv/dummy_joint' attached_to='wamv/base_link'>
+        <pose>0 0 0 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/dummy_link' attached_to='wamv/dummy_joint'/>
+      <frame name='wamv/hydrophones_pinger_joint' attached_to='wamv/base_link'>
+        <pose>1 0 -1 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/hydrophones' attached_to='wamv/hydrophones_pinger_joint'/>
+      <pose>-532 162 0.1 0 -0 1</pose>
+    </model>
+    <state world_name='vrx_scan_dock_deliver'>
+      <sim_time>170 450000000</sim_time>
+      <real_time>219 308925804</real_time>
+      <wall_time>1725827493 699849534</wall_time>
+      <iterations>102716</iterations>
+      <model name='antenna'>
+        <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='blue_projectile'>
+        <pose>-545 60 0.072128 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-545 60 0.072128 0 -0 0</pose>
+          <velocity>0 0 -0.010946 0 -0 0</velocity>
+          <acceleration>0 0 -0.15252 0 -0 0</acceleration>
+          <wrench>0 0 -0.006101 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_0'>
+        <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-540.743 146.687 1.66777 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-539.972 146.474 1.67444 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-541.727 146.128 1.67569 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-541.531 147.215 1.6548 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-540.049 147.325 1.65735 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_1'>
+        <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-537.569 146.021 1.6782 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-536.798 145.808 1.68302 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-538.553 145.462 1.68831 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-538.357 146.549 1.66717 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-536.875 146.659 1.66628 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_2'>
+        <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-534.497 145.103 1.71632 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-533.726 144.89 1.72031 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-535.481 144.545 1.72896 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-535.285 145.632 1.70558 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-533.803 145.741 1.70217 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ocean_waves'>
+        <pose>6.80666 -14.7297 0 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='ocean_waves_link'>
+          <pose>6.80666 -14.7297 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_0'>
+        <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_1'>
+        <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_2'>
+        <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='robotx_light_buoy'>
+        <pose>-544.261 208.339 0.402847 0 -0 3.14</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-544.261 208.339 0.402847 0 -0 3.14</pose>
+          <velocity>0 0 -0.003135 0 -0 0</velocity>
+          <acceleration>0 0 0.022338 0 -0 0</acceleration>
+          <wrench>0 0 1.49999 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='sydneyregatta'>
+        <pose>0 0 0.2 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>0 0 0.2 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='wamv'>
+        <pose>-524.108 201.163 -0.137363 0.000246 -0.003204 1.00038</pose>
+        <scale>1 1 1</scale>
+        <link name='BL_engine_link'>
+          <pose>-526.077 200.132 0.174957 -0.002092 -0.00244 1.78577</pose>
+          <velocity>-0.003628 -0.00127 -0.037557 0.017636 -0.01295 -7e-05</velocity>
+          <acceleration>-0.00142 -0.005139 -0.031974 0.028712 -0.0121 0.000338</acceleration>
+          <wrench>-0.021303 -0.07709 -0.479616 0 -0 0</wrench>
+        </link>
+        <link name='BL_propeller_link'>
+          <pose>-526.016 199.861 -0.33509 -0.002092 -0.00244 1.78577</pose>
+          <velocity>0.002958 0.007721 -0.041546 0.017636 -0.01295 -7e-05</velocity>
+          <acceleration>0.004793 0.009884 -0.03893 0.029257 -0.011804 0.000523</acceleration>
+          <wrench>0.002396 0.004942 -0.019465 0 -0 0</wrench>
+        </link>
+        <link name='BR_engine_link'>
+          <pose>-524.225 198.944 0.174416 0.00244 -0.002092 0.214995</pose>
+          <velocity>-0.003707 -0.001395 -0.034529 0.017636 -0.01295 -6.7e-05</velocity>
+          <acceleration>-0.001351 -0.005018 -0.044879 0.029086 -0.011817 -0.00036</acceleration>
+          <wrench>-0.020269 -0.075272 -0.673182 0 -0 0</wrench>
+        </link>
+        <link name='BR_propeller_link'>
+          <pose>-524.496 198.886 -0.335534 0.00244 -0.002092 0.214995</pose>
+          <velocity>0.002893 0.007616 -0.039059 0.017636 -0.01295 -6.7e-05</velocity>
+          <acceleration>0.004708 0.01007 -0.049527 0.029257 -0.011803 -0.000322</acceleration>
+          <wrench>0.002354 0.005035 -0.024764 0 -0 0</wrench>
+        </link>
+        <link name='FL_engine_link'>
+          <pose>-523.775 202.682 0.364195 0.00244 -0.002092 0.21499</pose>
+          <velocity>-0.005893 -0.004774 0.037236 0.017636 -0.01295 -4.3e-05</velocity>
+          <acceleration>-0.004839 -0.011794 0.069732 0.029099 -0.011793 0</acceleration>
+          <wrench>-0.072592 -0.176905 1.04597 0 -0 0</wrench>
+        </link>
+        <link name='FL_propeller_link'>
+          <pose>-524.046 202.624 -0.145755 0.00244 -0.002092 0.21499</pose>
+          <velocity>0.000709 0.004231 0.032706 0.017636 -0.01295 -4.3e-05</velocity>
+          <acceleration>0.001241 0.003196 0.065083 0.029257 -0.011804 3.9e-05</acceleration>
+          <wrench>0.00062 0.001598 0.032541 0 -0 0</wrench>
+        </link>
+        <link name='FR_engine_link'>
+          <pose>-522.866 202.099 0.363749 -0.002092 -0.00244 1.78577</pose>
+          <velocity>-0.005929 -0.004833 0.038723 0.017636 -0.01295 -0.000103</velocity>
+          <acceleration>-0.004803 -0.011729 0.063397 0.028703 -0.01212 -3.8e-05</acceleration>
+          <wrench>-0.072052 -0.175934 0.950952 0 -0 0</wrench>
+        </link>
+        <link name='FR_propeller_link'>
+          <pose>-522.806 201.829 -0.146298 -0.002092 -0.00244 1.78577</pose>
+          <velocity>0.000648 0.004156 0.034734 0.017636 -0.01295 -0.000103</velocity>
+          <acceleration>0.001307 0.003272 0.056441 0.029257 -0.011804 0.000145</acceleration>
+          <wrench>0.000654 0.001636 0.02822 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_base_link'>
+          <pose>-524.071 201.776 1.16443 -7.5e-05 -0.003213 1.10038</pose>
+          <velocity>-0.016322 -0.018866 0.017421 0.017636 -0.01295 -7.4e-05</velocity>
+          <acceleration>-0.014605 -0.036301 0.038684 0.044843 -0.015317 -0.003834</acceleration>
+          <wrench>-0.007302 -0.018151 0.019342 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_launcher_link'>
+          <pose>-524.08 201.758 1.27225 -0.000108 -0.803213 1.10046</pose>
+          <velocity>-0.017719 -0.020767 0.016973 0.017636 -0.01295 -7.4e-05</velocity>
+          <acceleration>-0.015289 -0.037994 0.038638 -0.015633 -0.049866 -0.0482</acceleration>
+          <wrench>-0.007645 -0.018997 0.019319 0 -0 0</wrench>
+        </link>
+        <link name='wamv/base_link'>
+          <pose>-524.108 201.163 -0.137363 0.000246 -0.003204 1.00038</pose>
+          <velocity>0.000492 0.004095 0.006132 0.017636 -0.01295 -7.3e-05</velocity>
+          <acceleration>0.001299 0.002628 0.021974 -0.321733 -0.266267 -0.007143</acceleration>
+          <wrench>0.237553 0.480329 4.01702 0 -0 0</wrench>
+        </link>
+        <link name='wamv/imu_wamv_link'>
+          <pose>-524.124 201.453 1.36344 0.000246 -0.003204 1.00038</pose>
+          <velocity>-0.018922 -0.022372 0.011035 0.017636 -0.01295 -7.3e-05</velocity>
+          <acceleration>-0.016191 -0.040598 0.029164 0.029155 -0.011933 9.6e-05</acceleration>
+          <wrench>-0.001619 -0.00406 0.002916 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ins_link'>
+          <pose>-524.124 201.453 1.36344 0.000246 -0.003204 1.00038</pose>
+          <velocity>-0.018922 -0.022372 0.011035 0.017636 -0.01295 -7.3e-05</velocity>
+          <acceleration>-0.016191 -0.040598 0.029164 0.029257 -0.011804 9.1e-05</acceleration>
+          <wrench>-0.016191 -0.040598 0.029164 0 -0 0</wrench>
+        </link>
+      </model>
+      <light name='sun'>
+        <pose>0 0 10 0 -0 0</pose>
+      </light>
+    </state>
+  </world>
+</sdf>

--- a/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/multiple.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/multiple.world
@@ -1,0 +1,4130 @@
+<sdf version='1.7'>
+  <world name='vrx_scan_dock_deliver'>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>1</shadows>
+    </scene>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.7242</latitude_deg>
+      <longitude_deg>150.68</longitude_deg>
+      <elevation>0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+    <light name='sun' type='directional'>
+      <cast_shadows>1</cast_shadows>
+      <pose>0 0 10 0 -0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>-506.401 167.68 8.60196 0 0.248344 2.93686</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+    <model name='sydneyregatta'>
+      <pose>0 0 0.2 0 -0 0</pose>
+      <static>1</static>
+      <link name='link'>
+        <visual name='visual_terrain'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Terrain</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_concrete'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>ConcreteDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>DockDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_metal_galvanized'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>MetalGalvanized</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Dock</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_windows_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Windows_Dark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_roof'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>RoofCorrugated</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_wall'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Wall</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_branches'>
+          <geometry>
+            <mesh>
+              <uri>model://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>TreeDiffuse</name>
+              </submesh>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://sydney_regatta/materials/scripts/</uri>
+              <uri>model://sydney_regatta/materials/textures/</uri>
+              <name>SydneyTree/Branch</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta_shore.dae</uri>
+            </mesh>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_0'>
+      <static>1</static>
+      <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_1'>
+      <static>1</static>
+      <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_2'>
+      <static>1</static>
+      <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='antenna'>
+      <static>1</static>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://antenna/meshes/antenna.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.95 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.35</radius>
+              <length>1.9</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+    </model>
+    <model name='ground_station_0'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+    </model>
+    <model name='ground_station_1'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+    </model>
+    <model name='ground_station_2'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+    </model>
+    <model name='blue_projectile'>
+      <link name='link'>
+        <inertial>
+          <mass>0.04</mass>
+          <inertia>
+            <ixx>2.166e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2166</iyy>
+            <iyz>0</iyz>
+            <izz>2166</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://blue_projectile/materials/scripts/blue_projectile.material</uri>
+              <name>blue_projectile/Blue</name>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name='buoyancy_sphere'>
+          <link_name>link</link_name>
+          <pose>0 0 -0.02 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+      </plugin>
+      <pose>-545 60 0.03 0 -0 0</pose>
+    </model>
+    <model name='ocean_waves'>
+      <static>1</static>
+      <plugin name='ocean_waves::wavefield_entity' filename='libWavefieldModelPlugin.so'>
+        <static>0</static>
+        <update_rate>30</update_rate>
+        <size>1000 1000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>5</period>
+          <number>3</number>
+          <scale>2.5</scale>
+          <gain>0.1</gain>
+          <direction>1.0 0.0</direction>
+          <angle>0.4</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name='ocean_waves_link'>
+        <visual name='ocean_waves_visual'>
+          <plugin name='ocean_waves_visual_plugin' filename='libWavefieldVisualPlugin.so'>
+            <enableRtt>1</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>5</period>
+              <number>3</number>
+              <scale>2.5</scale>
+              <gain>0.1</gain>
+              <direction>1.0 0.0</direction>
+              <angle>0.4</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name='ocean_waves_below_visual'>
+          <pose>0 0 -0.05 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <plugin name='wind' filename='libusv_gazebo_wind_plugin.so'>
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector>.5 .5 .33</coeff_vector>
+      </wind_obj>
+      <wind_direction>270</wind_direction>
+      <wind_mean_velocity>0</wind_mean_velocity>
+      <var_wind_gain_constants>0</var_wind_gain_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
+      <random_seed/>
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <model name='robotx_light_buoy'>
+      <pose>-511 218 0.25 0 -0 3.14</pose>
+      <link name='base_link'>
+        <inertial>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <mass>67.15</mass>
+          <inertia>
+            <ixx>13.486</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>13.486</iyy>
+            <iyz>0</iyz>
+            <izz>25.1813</izz>
+          </inertia>
+        </inertial>
+        <visual name='base'>
+          <geometry>
+            <mesh>
+              <uri>file://robotx_light_buoy/mesh/robotx_light_buoy.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='panel_1'>
+          <pose>-0.05 0.09 1.3 0 -0 0.5</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+          <plugin name='lightplugin' filename='liblight_buoy_plugin.so'>
+            <color_1>off</color_1>
+            <color_2>off</color_2>
+            <color_3>off</color_3>
+            <visuals>
+              <visual>robotx_light_buoy::base_link::panel_1</visual>
+              <visual>robotx_light_buoy::base_link::panel_2</visual>
+              <visual>robotx_light_buoy::base_link::panel_3</visual>
+            </visuals>
+            <robot_namespace>vrx</robot_namespace>
+            <topic>light_buoy/shuffle</topic>
+          </plugin>
+        </visual>
+        <visual name='panel_2'>
+          <pose>-0.06 -0.085 1.3 0 0 -0.54719</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <visual name='panel_3'>
+          <pose>0.11 -0.003 1.3 0 -0 1.5472</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision_base'>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='collision_body'>
+          <pose>0 0 0.85 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.4</radius>
+              <length>1.75</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>1000.0</linear_drag>
+        <angular_drag>200.0</angular_drag>
+        <buoyancy name='buoyancy_base'>
+          <link_name>base_link</link_name>
+          <pose>0 0 -0.2 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <buoyancy name='buoyancy_body'>
+          <link_name>base_link</link_name>
+          <pose>0 0 0.8 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.15</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+      </plugin>
+    </model>
+    <plugin name='contain_placard1_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard1_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='scan_dock__deliver_scoring_plugin' filename='libscan_dock_scoring_plugin.so'>
+      <vehicle>wamv</vehicle>
+      <task_name>scan_dock_deliver</task_name>
+      <initial_state_duration>3</initial_state_duration>
+      <ready_state_duration>3</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <robot_namespace>vrx</robot_namespace>
+      <color_sequence_service>scan_dock_deliver/color_sequence</color_sequence_service>
+      <color_1>blue</color_1>
+      <color_2>green</color_2>
+      <color_3>red</color_3>
+      <dock_bonus_points>15</dock_bonus_points>
+      <correct_dock_bonus_points>5</correct_dock_bonus_points>
+      <bays>
+        <bay>
+          <name>bay1</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>red_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay2</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>1</dock_allowed>
+          <symbol>blue_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay3</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>yellow_rectangle</symbol>
+        </bay>
+      </bays>
+      <targets>
+        <target>
+          <topic>vrx/dock_2022_placard1_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard1_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+      </targets>
+    </plugin>
+    <plugin name='vehicle_docked_bay1' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay1_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+    <physics type='ode'>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+    </physics>
+    <wind/>
+    <model name='wamv'>
+      <link name='wamv/base_link'>
+        <inertial>
+          <pose>0.012722 0 0.026171 0 -0 0</pose>
+          <mass>182.806</mass>
+          <inertia>
+            <ixx>128.232</ixx>
+            <ixy>-2.4178e-21</ixy>
+            <ixz>-3.85993</ixz>
+            <iyy>403.15</iyy>
+            <iyz>-9.28107e-22</iyz>
+            <izz>447.942</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_collision_collision'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_collision_collision_1'>
+          <pose>0.95 0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_lens_collision_collision_2'>
+          <pose>0.987607 0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_box_collision_collision_3'>
+          <pose>0.949948 0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_collision_collision_4'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_collision_collision_5'>
+          <pose>0.95 -0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_lens_collision_collision_6'>
+          <pose>0.987607 -0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_box_collision_collision_7'>
+          <pose>0.949948 -0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_collision_collision_8'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_collision_collision_9'>
+          <pose>0.734 0 1.95 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_collision_collision_10'>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.075</length>
+              <radius>0.055</radius>
+            </cylinder>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <friction>
+              <ode/>
+              <torsional>
+                <ode/>
+              </torsional>
+            </friction>
+            <bounce/>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_float_collision_11'>
+          <pose>-0.4 1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_mid_float_collision_12'>
+          <pose>1.85 1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_front_float_collision_13'>
+          <pose>2.3 1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_lower_collision_14'>
+          <pose>0.9 0.85 1 0.78 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_upper_collision_15'>
+          <pose>0.9 0.6 1.18 1.35 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_lower_collision_16'>
+          <pose>-0.65 0.99 0.7 0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_medium_collision_17'>
+          <pose>-0.57 0.87 1.05 0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_upper_collision_18'>
+          <pose>-0.55 0.65 1.17 1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_lower_collision_19'>
+          <pose>-0.74 1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_medium_collision_20'>
+          <pose>-0.79 0.91 1.05 0.75 -0.15 -0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_upper_collision_21'>
+          <pose>-0.81 0.67 1.18 1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_joint_collision_22'>
+          <pose>0.58 1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_float_collision_23'>
+          <pose>-0.4 -1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_mid_float_collision_24'>
+          <pose>1.85 -1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_front_float_collision_25'>
+          <pose>2.3 -1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_lower_collision_26'>
+          <pose>0.9 -0.85 1 -0.78 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_upper_collision_27'>
+          <pose>0.9 -0.6 1.18 -1.35 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_lower_collision_28'>
+          <pose>-0.65 -0.99 0.7 -0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_medium_collision_29'>
+          <pose>-0.57 -0.87 1.05 -0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_upper_collision_30'>
+          <pose>-0.55 -0.65 1.17 -1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_lower_collision_31'>
+          <pose>-0.74 -1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_medium_collision_32'>
+          <pose>-0.79 -0.91 1.05 -0.75 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_upper_collision_33'>
+          <pose>-0.81 -0.67 1.18 -1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_joint_collision_34'>
+          <pose>0.58 -1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__top_base_collision_35'>
+          <pose>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.85 1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__hydrophones_collision_collision_36'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_left_cam_post_link_visual'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_visual_visual_1'>
+          <pose>0.912 0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_visual_visual_2'>
+          <pose>0.937721 0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_right_cam_post_link_visual_3'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_visual_visual_4'>
+          <pose>0.912 -0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_visual_visual_5'>
+          <pose>0.937721 -0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_link_visual_6'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_visual_visual_7'>
+          <pose>0.696 0 1.947 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_visual_visual_8'>
+          <pose>0.764941 0 1.96619 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/3d_lidar/mesh/3d_lidar.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/dummy_link_visual_9'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/WAM-V-Base/mesh/WAM-V-Base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/hydrophones_visual_10'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name='front_left_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_left_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_left_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_left_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_left_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='front_right_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_right_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_right_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_right_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_right_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 -0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='velodyne_sensor' type='gpu_ray'>
+          <update_rate>10</update_rate>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>18750</samples>
+                <resolution>0.1</resolution>
+                <min_angle>-3.14159</min_angle>
+                <max_angle>3.14159</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>16</samples>
+                <resolution>1</resolution>
+                <min_angle>-0.261799</min_angle>
+                <max_angle>0.261799</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>0.1</min>
+              <max>130</max>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.01</stddev>
+            </noise>
+          </ray>
+          <plugin name='velodyne_plugin' filename='libgazebo_ros_velodyne_gpu_laser.so'>
+            <topicName>velodyne_points</topicName>
+            <frameName>velodyne</frameName>
+            <min_intensity>0</min_intensity>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+        </sensor>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 1.1 0.318237 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_engine_link'>
+        <pose relative_to='BL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BL_engine_link</parent>
+        <child>BL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_propeller_link'>
+        <pose relative_to='BL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_propeller_link_fixed_joint_lump__BL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 -1.1 0.318237 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_engine_link'>
+        <pose relative_to='BR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BR_engine_link</parent>
+        <child>BR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_propeller_link'>
+        <pose relative_to='BR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_propeller_link_fixed_joint_lump__BR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 0.54 0.49675 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_engine_link'>
+        <pose relative_to='FL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FL_engine_link</parent>
+        <child>FL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_propeller_link'>
+        <pose relative_to='FL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_propeller_link_fixed_joint_lump__FL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 -0.54 0.49657 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_engine_link'>
+        <pose relative_to='FR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FR_engine_link</parent>
+        <child>FR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_propeller_link'>
+        <pose relative_to='FR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_propeller_link_fixed_joint_lump__FR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_base_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.54 0.3 1.3 0 -0 0.1</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ball_shooter_base_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_base_link'>
+        <pose relative_to='wamv/ball_shooter_base_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>-0.02 0 0.05 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00083</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00052083</iyy>
+            <iyz>0</iyz>
+            <izz>0.00052083</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/ball_shooter_base_link_fixed_joint_lump__ball_shooter_base_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_launcher_joint' type='revolute'>
+        <pose relative_to='wamv/ball_shooter_base_link'>-0.0204 0 0.107877 0 -0.8 0</pose>
+        <parent>wamv/ball_shooter_base_link</parent>
+        <child>wamv/ball_shooter_launcher_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_launcher_link'>
+        <pose relative_to='wamv/ball_shooter_launcher_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 3.14159 -1.57079 3.14159</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00177917</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00177917</iyy>
+            <iyz>0</iyz>
+            <izz>0.000225</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_collision_collision'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <box>
+              <size>0.3 0.3 0.2</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_launcher_visual_visual'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_launcher.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/imu_wamv_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/imu_wamv_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/imu_wamv_link'>
+        <pose relative_to='wamv/imu_wamv_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.1</mass>
+          <inertia>
+            <ixx>8.3e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>8.3e-05</iyy>
+            <iyz>0</iyz>
+            <izz>0.0125</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/imu_wamv_link_fixed_joint_lump__imu_wamv_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.05 0.025 0.005</size>
+            </box>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ins_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ins_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ins_link'>
+        <pose relative_to='wamv/ins_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.006458</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.006458</iyy>
+            <iyz>0</iyz>
+            <izz>0.01125</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_base_collision'>
+          <pose>0 0 0.025 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.05</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_antenna_collision_1'>
+          <pose>0 0 0.11 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.15</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ins_link_fixed_joint_lump__ins_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_gazebo/models/gps/mesh/gps.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='gps_plugin_ins' filename='libhector_gazebo_ros_gps.so'>
+        <updateRate>15</updateRate>
+        <alwaysOn>1</alwaysOn>
+        <bodyName>wamv/ins_link</bodyName>
+        <frameId>wamv/ins_link</frameId>
+        <topicName>wamv/sensors/gps/gps/fix</topicName>
+        <velocityTopicName>wamv/sensors/gps/gps/fix_velocity</velocityTopicName>
+        <useWorldSphericalCoordinates>1</useWorldSphericalCoordinates>
+        <offset>0.0 0.0 0.0</offset>
+        <drift>0.0 0.0 0.0</drift>
+        <gaussianNoise>0 0 0</gaussianNoise>
+        <velocityOffset>0.0 0.0 0.0</velocityOffset>
+        <velocityDrift>0.0 0.0 0.0</velocityDrift>
+        <velocityGaussianNoise>0.0 0.0 0.0</velocityGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='imu_plugin_imu_wamv' filename='libhector_gazebo_ros_imu.so'>
+        <updateRate>15</updateRate>
+        <bodyName>wamv/imu_wamv_link</bodyName>
+        <topicName>wamv/sensors/imu/imu/data</topicName>
+        <serviceName>wamv/sensors/imu_service</serviceName>
+        <frameId>wamv/imu_wamv_link</frameId>
+        <alwaysOn>1</alwaysOn>
+        <accelOffset>0.0 0.0 0.0</accelOffset>
+        <accelDrift>0.0 0.0 0.0</accelDrift>
+        <accelDriftFrequency>0.00027 0.00027 0.000027</accelDriftFrequency>
+        <accelGaussianNoise>0.0 0.0 0.0</accelGaussianNoise>
+        <rateOffset>0.0 0.0 0.0</rateOffset>
+        <rateDrift>0.0 0.0 0.0</rateDrift>
+        <rateDriftFrequency>0.00027 0.00027 0.000027</rateDriftFrequency>
+        <rateGaussianNoise>0.0 0.0 0.0</rateGaussianNoise>
+        <yawOffset>0.0</yawOffset>
+        <yawDrift>0.0</yawDrift>
+        <yawDriftFrequency>0.00027</yawDriftFrequency>
+        <yawGaussianNoise>0.0</yawGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='ball_shooter_plugin' filename='libball_shooter_plugin.so'>
+        <projectile>
+          <model_name>blue_projectile</model_name>
+          <link_name>link</link_name>
+          <frame>wamv/ball_shooter_launcher_link</frame>
+          <pose>0.14 0 0 0 0 0</pose>
+        </projectile>
+        <num_shots>4</num_shots>
+        <shot_force>300</shot_force>
+        <topic>wamv/shooters/ball_shooter/fire</topic>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='pinger_plugin' filename='libusv_gazebo_acoustic_pinger_plugin.so'>
+        <frameId>wamv/pinger</frameId>
+        <topicName>wamv/sensors/pingers/hydrophones/range_bearing</topicName>
+        <setPositionTopicName>wamv/sensors/pingers/hydrophones/set_pinger_position</setPositionTopicName>
+        <rangeNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>3.0</stddev>
+          </noise>
+        </rangeNoise>
+        <bearingNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </bearingNoise>
+        <elevationNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </elevationNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='wamv_gazebo_thrust' filename='libusv_gazebo_thrust_plugin.so'>
+        <cmdTimeout>1.0</cmdTimeout>
+        <robotNamespace>wamv</robotNamespace>
+        <thruster>
+          <linkName>BL_propeller_link</linkName>
+          <propJointName>BL_engine_propeller_joint</propJointName>
+          <engineJointName>BL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>BR_propeller_link</linkName>
+          <propJointName>BR_engine_propeller_joint</propJointName>
+          <engineJointName>BR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FL_propeller_link</linkName>
+          <propJointName>FL_engine_propeller_joint</propJointName>
+          <engineJointName>FL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FR_propeller_link</linkName>
+          <propJointName>FR_engine_propeller_joint</propJointName>
+          <engineJointName>FR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+      </plugin>
+      <plugin name='usv_dynamics_wamv_dynamics_plugin' filename='libusv_gazebo_dynamics_plugin.so'>
+        <bodyName>wamv/base_link</bodyName>
+        <waterLevel>0</waterLevel>
+        <waterDensity>997.8</waterDensity>
+        <xDotU>0.0</xDotU>
+        <yDotV>0.0</yDotV>
+        <nDotR>0.0</nDotR>
+        <xU>51.3</xU>
+        <xUU>72.4</xUU>
+        <yV>40.0</yV>
+        <yVV>0.0</yVV>
+        <zW>500.0</zW>
+        <kP>50.0</kP>
+        <mQ>50.0</mQ>
+        <nR>400.0</nR>
+        <nRR>0.0</nRR>
+        <hullRadius>0.213</hullRadius>
+        <boatWidth>2.4</boatWidth>
+        <boatLength>4.9</boatLength>
+        <length_n>2</length_n>
+        <wave_model>ocean_waves</wave_model>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <frame name='wamv/front_left_cam_to_front_left_cam_link_optical_joint' attached_to='wamv/front_left_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link_optical' attached_to='wamv/front_left_cam_to_front_left_cam_link_optical_joint'/>
+      <frame name='wamv/front_left_cam_post_arm_to_front_left_cam_joint' attached_to='wamv/front_left_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link' attached_to='wamv/front_left_cam_post_arm_to_front_left_cam_joint'/>
+      <frame name='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint' attached_to='wamv/front_left_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_arm_link' attached_to='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_left_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_link' attached_to='wamv/base_to_front_left_cam_post_joint'/>
+      <frame name='wamv/front_right_cam_to_front_right_cam_link_optical_joint' attached_to='wamv/front_right_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link_optical' attached_to='wamv/front_right_cam_to_front_right_cam_link_optical_joint'/>
+      <frame name='wamv/front_right_cam_post_arm_to_front_right_cam_joint' attached_to='wamv/front_right_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link' attached_to='wamv/front_right_cam_post_arm_to_front_right_cam_joint'/>
+      <frame name='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint' attached_to='wamv/front_right_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_arm_link' attached_to='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_right_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_link' attached_to='wamv/base_to_front_right_cam_post_joint'/>
+      <frame name='wamv/velodyne_post_arm_to_velodyne_joint' attached_to='velodyne_post_arm_link'>
+        <pose>0.04 0 0.05 0 0.261799 0</pose>
+      </frame>
+      <frame name='velodyne' attached_to='wamv/velodyne_post_arm_to_velodyne_joint'/>
+      <frame name='wamv/velodyne_post_to_velodyne_post_arm_joint' attached_to='velodyne_post_link'>
+        <pose>0.03 0 0.32675 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_arm_link' attached_to='wamv/velodyne_post_to_velodyne_post_arm_joint'/>
+      <frame name='wamv/base_to_velodyne_post_joint' attached_to='wamv/base_link'>
+        <pose>0.704 0 1.62325 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_link' attached_to='wamv/base_to_velodyne_post_joint'/>
+      <frame name='wamv/dummy_joint' attached_to='wamv/base_link'>
+        <pose>0 0 0 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/dummy_link' attached_to='wamv/dummy_joint'/>
+      <frame name='wamv/hydrophones_pinger_joint' attached_to='wamv/base_link'>
+        <pose>1 0 -1 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/hydrophones' attached_to='wamv/hydrophones_pinger_joint'/>
+      <pose>-532 162 0.1 0 -0 1</pose>
+    </model>
+    <state world_name='vrx_scan_dock_deliver'>
+      <sim_time>100 305000000</sim_time>
+      <real_time>66 716441280</real_time>
+      <wall_time>1725827858 165667124</wall_time>
+      <iterations>32571</iterations>
+      <model name='antenna'>
+        <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='blue_projectile'>
+        <pose>-545 60 0.072178 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-545 60 0.072178 0 -0 0</pose>
+          <velocity>0 0 0.009888 0 -0 0</velocity>
+          <acceleration>0 0 -0.131615 0 -0 0</acceleration>
+          <wrench>0 0 -0.005265 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_0'>
+        <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-540.743 146.687 1.66777 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-539.972 146.474 1.67444 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-541.727 146.128 1.67569 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-541.531 147.215 1.6548 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-540.049 147.325 1.65735 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_1'>
+        <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-537.569 146.021 1.6782 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-536.798 145.808 1.68302 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-538.553 145.462 1.68831 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-538.357 146.549 1.66717 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-536.875 146.659 1.66628 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_2'>
+        <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-534.497 145.103 1.71632 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-533.726 144.89 1.72031 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-535.481 144.545 1.72896 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-535.285 145.632 1.70558 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-533.803 145.741 1.70217 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ocean_waves'>
+        <pose>1.26646 -4.11833 0 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='ocean_waves_link'>
+          <pose>1.26646 -4.11833 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_0'>
+        <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_1'>
+        <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_2'>
+        <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='robotx_light_buoy'>
+        <pose>-522.747 167.592 0.333994 0 -0 3.14</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-522.747 167.592 0.333994 0 -0 3.14</pose>
+          <velocity>0 0 0.012054 0 -0 0</velocity>
+          <acceleration>0 0 0.003624 0 -0 0</acceleration>
+          <wrench>0 0 0.243378 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='robotx_light_buoy_clone'>
+        <pose>-539.743 170.14 0.408057 0 -0 3.14</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-539.743 170.14 0.408057 0 -0 3.14</pose>
+          <velocity>0 0 0.001209 0 -0 0</velocity>
+          <acceleration>0 0 -0.078127 0 -0 0</acceleration>
+          <wrench>0 0 -5.24625 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='sydneyregatta'>
+        <pose>0 0 0.2 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>0 0 0.2 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='wamv'>
+        <pose>-532.095 162.197 -0.115115 0.007005 0.00364 1.00023</pose>
+        <scale>1 1 1</scale>
+        <link name='BL_engine_link'>
+          <pose>-534.061 161.166 0.217844 0.007527 -0.00238 1.78563</pose>
+          <velocity>0.002912 0.003841 0.101415 -0.009423 0.017268 0.000165</velocity>
+          <acceleration>-0.006507 -0.000162 -0.018543 0.009585 -0.034067 0.00044</acceleration>
+          <wrench>-0.097602 -0.002437 -0.278142 0 -0 0</wrench>
+        </link>
+        <link name='BL_propeller_link'>
+          <pose>-534.005 160.895 -0.292173 0.007527 -0.00238 1.78563</pose>
+          <velocity>-0.005851 -0.000956 0.103017 -0.009423 0.017268 0.000165</velocity>
+          <acceleration>0.010281 0.004323 -0.018908 0.008832 -0.033164 -0.00061</acceleration>
+          <wrench>0.00514 0.002162 -0.009454 0 -0 0</wrench>
+        </link>
+        <link name='BR_engine_link'>
+          <pose>-532.209 159.978 0.202432 0.00238 0.007527 0.214837</pose>
+          <velocity>0.002753 0.003863 0.080642 -0.009424 0.017268 6.9e-05</velocity>
+          <acceleration>-0.006876 -0.001033 0.032368 0.008974 -0.033186 0.000637</acceleration>
+          <wrench>-0.103136 -0.01549 0.485523 0 -0 0</wrench>
+        </link>
+        <link name='BR_propeller_link'>
+          <pose>-532.485 159.919 -0.304829 0.00238 0.007527 0.214837</pose>
+          <velocity>-0.006002 -0.000936 0.085959 -0.009424 0.017268 6.9e-05</velocity>
+          <acceleration>0.010016 0.003605 0.0229 0.008832 -0.033164 -0.000433</acceleration>
+          <wrench>0.005008 0.001803 0.01145 0 -0 0</wrench>
+        </link>
+        <link name='FL_engine_link'>
+          <pose>-531.757 163.717 0.380088 0.00238 0.007527 0.214837</pose>
+          <velocity>0.005483 0.005578 0.037594 -0.009424 0.017268 6.7e-05</velocity>
+          <acceleration>-0.011878 -0.003206 0.080325 0.008962 -0.033185 0.000613</acceleration>
+          <wrench>-0.178167 -0.048084 1.20488 0 -0 0</wrench>
+        </link>
+        <link name='FL_propeller_link'>
+          <pose>-532.033 163.658 -0.127173 0.00238 0.007527 0.214837</pose>
+          <velocity>-0.003273 0.00078 0.042911 -0.009424 0.017268 6.7e-05</velocity>
+          <acceleration>0.005013 0.001439 0.070857 0.008832 -0.033164 -0.000456</acceleration>
+          <wrench>0.002507 0.000719 0.035428 0 -0 0</wrench>
+        </link>
+        <link name='FR_engine_link'>
+          <pose>-530.848 163.134 0.372342 0.007527 -0.00238 1.78563</pose>
+          <velocity>0.005402 0.005588 0.027396 -0.009423 0.017268 0.000175</velocity>
+          <acceleration>-0.012053 -0.003631 0.105318 0.009674 -0.034075 0.000455</acceleration>
+          <wrench>-0.180794 -0.054469 1.57977 0 -0 0</wrench>
+        </link>
+        <link name='FR_propeller_link'>
+          <pose>-530.793 162.862 -0.137675 0.007527 -0.00238 1.78563</pose>
+          <velocity>-0.003357 0.000792 0.028998 -0.009423 0.017268 0.000175</velocity>
+          <acceleration>0.004736 0.000855 0.104952 0.008832 -0.033164 -0.000602</acceleration>
+          <wrench>0.002368 0.000427 0.052476 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_base_link'>
+          <pose>-532.046 162.813 1.18498 0.007334 0.002922 1.10022</pose>
+          <velocity>0.019464 0.013137 0.051101 -0.009424 0.017268 9e-05</velocity>
+          <acceleration>-0.040395 -0.010493 0.061988 0.017987 -0.025469 -0.000314</acceleration>
+          <wrench>-0.020198 -0.005247 0.030994 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_launcher_link'>
+          <pose>-532.054 162.794 1.29291 0.010495 -0.79705 1.09269</pose>
+          <velocity>0.021329 0.014154 0.051418 -0.009424 0.017268 9e-05</velocity>
+          <acceleration>-0.042315 -0.011005 0.061972 -0.044205 -0.120878 -0.101649</acceleration>
+          <wrench>-0.021158 -0.005502 0.030986 0 -0 0</wrench>
+        </link>
+        <link name='wamv/base_link'>
+          <pose>-532.095 162.197 -0.115115 0.007005 0.00364 1.00023</pose>
+          <velocity>-0.002931 0.000881 0.057755 -0.009424 0.017268 9.1e-05</velocity>
+          <acceleration>0.003364 0.001269 0.056202 -0.326862 -0.248298 -0.00542</acceleration>
+          <wrench>0.615035 0.231944 10.2741 0 -0 0</wrench>
+        </link>
+        <link name='wamv/imu_wamv_link'>
+          <pose>-532.097 162.49 1.38515 0.007005 0.00364 1.00023</pose>
+          <velocity>0.02295 0.015019 0.055025 -0.009424 0.017268 9.1e-05</velocity>
+          <acceleration>-0.045446 -0.011766 0.057831 0.009334 -0.033217 -0.000534</acceleration>
+          <wrench>-0.004545 -0.001177 0.005783 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ins_link'>
+          <pose>-532.097 162.49 1.38515 0.007005 0.00364 1.00023</pose>
+          <velocity>0.02295 0.015019 0.055025 -0.009424 0.017268 9.1e-05</velocity>
+          <acceleration>-0.045446 -0.011766 0.057831 0.008832 -0.033164 -0.000477</acceleration>
+          <wrench>-0.045446 -0.011766 0.057831 0 -0 0</wrench>
+        </link>
+      </model>
+      <light name='sun'>
+        <pose>0 0 10 0 -0 0</pose>
+      </light>
+    </state>
+    <model name='robotx_light_buoy_clone'>
+      <pose>-539.743 170.14 0.403955 0 -0 3.14</pose>
+      <link name='base_link'>
+        <inertial>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <mass>67.15</mass>
+          <inertia>
+            <ixx>13.486</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>13.486</iyy>
+            <iyz>0</iyz>
+            <izz>25.1813</izz>
+          </inertia>
+        </inertial>
+        <visual name='base'>
+          <geometry>
+            <mesh>
+              <uri>file://robotx_light_buoy/mesh/robotx_light_buoy.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='panel_1'>
+          <pose>-0.05 0.09 1.3 0 -0 0.5</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+          <plugin name='lightplugin' filename='liblight_buoy_plugin.so'>
+            <color_1>off</color_1>
+            <color_2>off</color_2>
+            <color_3>off</color_3>
+            <visuals>
+              <visual>robotx_light_buoy::base_link::panel_1</visual>
+              <visual>robotx_light_buoy::base_link::panel_2</visual>
+              <visual>robotx_light_buoy::base_link::panel_3</visual>
+            </visuals>
+            <robot_namespace>vrx</robot_namespace>
+            <topic>light_buoy/shuffle</topic>
+          </plugin>
+        </visual>
+        <visual name='panel_2'>
+          <pose>-0.06 -0.085 1.3 0 0 -0.54719</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <visual name='panel_3'>
+          <pose>0.11 -0.003 1.3 0 -0 1.5472</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision_base'>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='collision_body'>
+          <pose>0 0 0.85 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.4</radius>
+              <length>1.75</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>1000.0</linear_drag>
+        <angular_drag>200.0</angular_drag>
+        <buoyancy name='buoyancy_base'>
+          <link_name>base_link</link_name>
+          <pose>0 0 -0.2 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <buoyancy name='buoyancy_body'>
+          <link_name>base_link</link_name>
+          <pose>0 0 0.8 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.15</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+      </plugin>
+    </model>
+  </world>
+</sdf>

--- a/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/none.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/none.world
@@ -1,0 +1,3810 @@
+<sdf version='1.7'>
+  <world name='vrx_scan_dock_deliver'>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>1</shadows>
+    </scene>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.7242</latitude_deg>
+      <longitude_deg>150.68</longitude_deg>
+      <elevation>0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+    <light name='sun' type='directional'>
+      <cast_shadows>1</cast_shadows>
+      <pose>0 0 10 0 -0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>-488.747 172.454 19.2696 0 0.248344 2.93686</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+    <model name='sydneyregatta'>
+      <pose>0 0 0.2 0 -0 0</pose>
+      <static>1</static>
+      <link name='link'>
+        <visual name='visual_terrain'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Terrain</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_concrete'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>ConcreteDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>DockDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_metal_galvanized'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>MetalGalvanized</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Dock</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_windows_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Windows_Dark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_roof'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>RoofCorrugated</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_wall'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Wall</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_branches'>
+          <geometry>
+            <mesh>
+              <uri>model://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>TreeDiffuse</name>
+              </submesh>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://sydney_regatta/materials/scripts/</uri>
+              <uri>model://sydney_regatta/materials/textures/</uri>
+              <name>SydneyTree/Branch</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta_shore.dae</uri>
+            </mesh>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_0'>
+      <static>1</static>
+      <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_1'>
+      <static>1</static>
+      <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_2'>
+      <static>1</static>
+      <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='antenna'>
+      <static>1</static>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://antenna/meshes/antenna.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.95 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.35</radius>
+              <length>1.9</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+    </model>
+    <model name='ground_station_0'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+    </model>
+    <model name='ground_station_1'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+    </model>
+    <model name='ground_station_2'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+    </model>
+    <model name='blue_projectile'>
+      <link name='link'>
+        <inertial>
+          <mass>0.04</mass>
+          <inertia>
+            <ixx>2.166e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2166</iyy>
+            <iyz>0</iyz>
+            <izz>2166</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://blue_projectile/materials/scripts/blue_projectile.material</uri>
+              <name>blue_projectile/Blue</name>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name='buoyancy_sphere'>
+          <link_name>link</link_name>
+          <pose>0 0 -0.02 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+      </plugin>
+      <pose>-545 60 0.03 0 -0 0</pose>
+    </model>
+    <model name='ocean_waves'>
+      <static>1</static>
+      <plugin name='ocean_waves::wavefield_entity' filename='libWavefieldModelPlugin.so'>
+        <static>0</static>
+        <update_rate>30</update_rate>
+        <size>1000 1000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>5</period>
+          <number>3</number>
+          <scale>2.5</scale>
+          <gain>0.1</gain>
+          <direction>1.0 0.0</direction>
+          <angle>0.4</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name='ocean_waves_link'>
+        <visual name='ocean_waves_visual'>
+          <plugin name='ocean_waves_visual_plugin' filename='libWavefieldVisualPlugin.so'>
+            <enableRtt>1</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>5</period>
+              <number>3</number>
+              <scale>2.5</scale>
+              <gain>0.1</gain>
+              <direction>1.0 0.0</direction>
+              <angle>0.4</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name='ocean_waves_below_visual'>
+          <pose>0 0 -0.05 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <plugin name='wind' filename='libusv_gazebo_wind_plugin.so'>
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector>.5 .5 .33</coeff_vector>
+      </wind_obj>
+      <wind_direction>270</wind_direction>
+      <wind_mean_velocity>0</wind_mean_velocity>
+      <var_wind_gain_constants>0</var_wind_gain_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
+      <random_seed/>
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <plugin name='contain_placard1_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard1_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='scan_dock__deliver_scoring_plugin' filename='libscan_dock_scoring_plugin.so'>
+      <vehicle>wamv</vehicle>
+      <task_name>scan_dock_deliver</task_name>
+      <initial_state_duration>3</initial_state_duration>
+      <ready_state_duration>3</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <robot_namespace>vrx</robot_namespace>
+      <color_sequence_service>scan_dock_deliver/color_sequence</color_sequence_service>
+      <color_1>blue</color_1>
+      <color_2>green</color_2>
+      <color_3>red</color_3>
+      <dock_bonus_points>15</dock_bonus_points>
+      <correct_dock_bonus_points>5</correct_dock_bonus_points>
+      <bays>
+        <bay>
+          <name>bay1</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>red_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay2</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>1</dock_allowed>
+          <symbol>blue_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay3</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>yellow_rectangle</symbol>
+        </bay>
+      </bays>
+      <targets>
+        <target>
+          <topic>vrx/dock_2022_placard1_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard1_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+      </targets>
+    </plugin>
+    <plugin name='vehicle_docked_bay1' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay1_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+    <physics type='ode'>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+    </physics>
+    <wind/>
+    <model name='wamv'>
+      <link name='wamv/base_link'>
+        <inertial>
+          <pose>0.012722 0 0.026171 0 -0 0</pose>
+          <mass>182.806</mass>
+          <inertia>
+            <ixx>128.232</ixx>
+            <ixy>-2.4178e-21</ixy>
+            <ixz>-3.85993</ixz>
+            <iyy>403.15</iyy>
+            <iyz>-9.28107e-22</iyz>
+            <izz>447.942</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_collision_collision'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_collision_collision_1'>
+          <pose>0.95 0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_lens_collision_collision_2'>
+          <pose>0.987607 0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_box_collision_collision_3'>
+          <pose>0.949948 0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_collision_collision_4'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_collision_collision_5'>
+          <pose>0.95 -0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_lens_collision_collision_6'>
+          <pose>0.987607 -0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_box_collision_collision_7'>
+          <pose>0.949948 -0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_collision_collision_8'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_collision_collision_9'>
+          <pose>0.734 0 1.95 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_collision_collision_10'>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.075</length>
+              <radius>0.055</radius>
+            </cylinder>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <friction>
+              <ode/>
+              <torsional>
+                <ode/>
+              </torsional>
+            </friction>
+            <bounce/>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_float_collision_11'>
+          <pose>-0.4 1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_mid_float_collision_12'>
+          <pose>1.85 1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_front_float_collision_13'>
+          <pose>2.3 1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_lower_collision_14'>
+          <pose>0.9 0.85 1 0.78 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_upper_collision_15'>
+          <pose>0.9 0.6 1.18 1.35 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_lower_collision_16'>
+          <pose>-0.65 0.99 0.7 0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_medium_collision_17'>
+          <pose>-0.57 0.87 1.05 0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_upper_collision_18'>
+          <pose>-0.55 0.65 1.17 1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_lower_collision_19'>
+          <pose>-0.74 1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_medium_collision_20'>
+          <pose>-0.79 0.91 1.05 0.75 -0.15 -0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_upper_collision_21'>
+          <pose>-0.81 0.67 1.18 1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_joint_collision_22'>
+          <pose>0.58 1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_float_collision_23'>
+          <pose>-0.4 -1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_mid_float_collision_24'>
+          <pose>1.85 -1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_front_float_collision_25'>
+          <pose>2.3 -1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_lower_collision_26'>
+          <pose>0.9 -0.85 1 -0.78 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_upper_collision_27'>
+          <pose>0.9 -0.6 1.18 -1.35 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_lower_collision_28'>
+          <pose>-0.65 -0.99 0.7 -0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_medium_collision_29'>
+          <pose>-0.57 -0.87 1.05 -0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_upper_collision_30'>
+          <pose>-0.55 -0.65 1.17 -1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_lower_collision_31'>
+          <pose>-0.74 -1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_medium_collision_32'>
+          <pose>-0.79 -0.91 1.05 -0.75 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_upper_collision_33'>
+          <pose>-0.81 -0.67 1.18 -1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_joint_collision_34'>
+          <pose>0.58 -1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__top_base_collision_35'>
+          <pose>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.85 1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__hydrophones_collision_collision_36'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_left_cam_post_link_visual'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_visual_visual_1'>
+          <pose>0.912 0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_visual_visual_2'>
+          <pose>0.937721 0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_right_cam_post_link_visual_3'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_visual_visual_4'>
+          <pose>0.912 -0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_visual_visual_5'>
+          <pose>0.937721 -0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_link_visual_6'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_visual_visual_7'>
+          <pose>0.696 0 1.947 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_visual_visual_8'>
+          <pose>0.764941 0 1.96619 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/3d_lidar/mesh/3d_lidar.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/dummy_link_visual_9'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/WAM-V-Base/mesh/WAM-V-Base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/hydrophones_visual_10'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name='front_left_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_left_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_left_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_left_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_left_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='front_right_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_right_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_right_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_right_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_right_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 -0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='velodyne_sensor' type='gpu_ray'>
+          <update_rate>10</update_rate>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>18750</samples>
+                <resolution>0.1</resolution>
+                <min_angle>-3.14159</min_angle>
+                <max_angle>3.14159</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>16</samples>
+                <resolution>1</resolution>
+                <min_angle>-0.261799</min_angle>
+                <max_angle>0.261799</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>0.1</min>
+              <max>130</max>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.01</stddev>
+            </noise>
+          </ray>
+          <plugin name='velodyne_plugin' filename='libgazebo_ros_velodyne_gpu_laser.so'>
+            <topicName>velodyne_points</topicName>
+            <frameName>velodyne</frameName>
+            <min_intensity>0</min_intensity>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+        </sensor>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 1.1 0.318237 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_engine_link'>
+        <pose relative_to='BL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BL_engine_link</parent>
+        <child>BL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_propeller_link'>
+        <pose relative_to='BL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_propeller_link_fixed_joint_lump__BL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 -1.1 0.318237 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_engine_link'>
+        <pose relative_to='BR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BR_engine_link</parent>
+        <child>BR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_propeller_link'>
+        <pose relative_to='BR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_propeller_link_fixed_joint_lump__BR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 0.54 0.49675 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_engine_link'>
+        <pose relative_to='FL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FL_engine_link</parent>
+        <child>FL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_propeller_link'>
+        <pose relative_to='FL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_propeller_link_fixed_joint_lump__FL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 -0.54 0.49657 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_engine_link'>
+        <pose relative_to='FR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FR_engine_link</parent>
+        <child>FR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_propeller_link'>
+        <pose relative_to='FR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_propeller_link_fixed_joint_lump__FR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_base_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.54 0.3 1.3 0 -0 0.1</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ball_shooter_base_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_base_link'>
+        <pose relative_to='wamv/ball_shooter_base_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>-0.02 0 0.05 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00083</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00052083</iyy>
+            <iyz>0</iyz>
+            <izz>0.00052083</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/ball_shooter_base_link_fixed_joint_lump__ball_shooter_base_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_launcher_joint' type='revolute'>
+        <pose relative_to='wamv/ball_shooter_base_link'>-0.0204 0 0.107877 0 -0.8 0</pose>
+        <parent>wamv/ball_shooter_base_link</parent>
+        <child>wamv/ball_shooter_launcher_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_launcher_link'>
+        <pose relative_to='wamv/ball_shooter_launcher_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 3.14159 -1.57079 3.14159</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00177917</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00177917</iyy>
+            <iyz>0</iyz>
+            <izz>0.000225</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_collision_collision'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <box>
+              <size>0.3 0.3 0.2</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_launcher_visual_visual'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_launcher.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/imu_wamv_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/imu_wamv_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/imu_wamv_link'>
+        <pose relative_to='wamv/imu_wamv_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.1</mass>
+          <inertia>
+            <ixx>8.3e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>8.3e-05</iyy>
+            <iyz>0</iyz>
+            <izz>0.0125</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/imu_wamv_link_fixed_joint_lump__imu_wamv_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.05 0.025 0.005</size>
+            </box>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ins_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ins_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ins_link'>
+        <pose relative_to='wamv/ins_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.006458</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.006458</iyy>
+            <iyz>0</iyz>
+            <izz>0.01125</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_base_collision'>
+          <pose>0 0 0.025 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.05</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_antenna_collision_1'>
+          <pose>0 0 0.11 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.15</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ins_link_fixed_joint_lump__ins_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_gazebo/models/gps/mesh/gps.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='gps_plugin_ins' filename='libhector_gazebo_ros_gps.so'>
+        <updateRate>15</updateRate>
+        <alwaysOn>1</alwaysOn>
+        <bodyName>wamv/ins_link</bodyName>
+        <frameId>wamv/ins_link</frameId>
+        <topicName>wamv/sensors/gps/gps/fix</topicName>
+        <velocityTopicName>wamv/sensors/gps/gps/fix_velocity</velocityTopicName>
+        <useWorldSphericalCoordinates>1</useWorldSphericalCoordinates>
+        <offset>0.0 0.0 0.0</offset>
+        <drift>0.0 0.0 0.0</drift>
+        <gaussianNoise>0 0 0</gaussianNoise>
+        <velocityOffset>0.0 0.0 0.0</velocityOffset>
+        <velocityDrift>0.0 0.0 0.0</velocityDrift>
+        <velocityGaussianNoise>0.0 0.0 0.0</velocityGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='imu_plugin_imu_wamv' filename='libhector_gazebo_ros_imu.so'>
+        <updateRate>15</updateRate>
+        <bodyName>wamv/imu_wamv_link</bodyName>
+        <topicName>wamv/sensors/imu/imu/data</topicName>
+        <serviceName>wamv/sensors/imu_service</serviceName>
+        <frameId>wamv/imu_wamv_link</frameId>
+        <alwaysOn>1</alwaysOn>
+        <accelOffset>0.0 0.0 0.0</accelOffset>
+        <accelDrift>0.0 0.0 0.0</accelDrift>
+        <accelDriftFrequency>0.00027 0.00027 0.000027</accelDriftFrequency>
+        <accelGaussianNoise>0.0 0.0 0.0</accelGaussianNoise>
+        <rateOffset>0.0 0.0 0.0</rateOffset>
+        <rateDrift>0.0 0.0 0.0</rateDrift>
+        <rateDriftFrequency>0.00027 0.00027 0.000027</rateDriftFrequency>
+        <rateGaussianNoise>0.0 0.0 0.0</rateGaussianNoise>
+        <yawOffset>0.0</yawOffset>
+        <yawDrift>0.0</yawDrift>
+        <yawDriftFrequency>0.00027</yawDriftFrequency>
+        <yawGaussianNoise>0.0</yawGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='ball_shooter_plugin' filename='libball_shooter_plugin.so'>
+        <projectile>
+          <model_name>blue_projectile</model_name>
+          <link_name>link</link_name>
+          <frame>wamv/ball_shooter_launcher_link</frame>
+          <pose>0.14 0 0 0 0 0</pose>
+        </projectile>
+        <num_shots>4</num_shots>
+        <shot_force>300</shot_force>
+        <topic>wamv/shooters/ball_shooter/fire</topic>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='pinger_plugin' filename='libusv_gazebo_acoustic_pinger_plugin.so'>
+        <frameId>wamv/pinger</frameId>
+        <topicName>wamv/sensors/pingers/hydrophones/range_bearing</topicName>
+        <setPositionTopicName>wamv/sensors/pingers/hydrophones/set_pinger_position</setPositionTopicName>
+        <rangeNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>3.0</stddev>
+          </noise>
+        </rangeNoise>
+        <bearingNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </bearingNoise>
+        <elevationNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </elevationNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='wamv_gazebo_thrust' filename='libusv_gazebo_thrust_plugin.so'>
+        <cmdTimeout>1.0</cmdTimeout>
+        <robotNamespace>wamv</robotNamespace>
+        <thruster>
+          <linkName>BL_propeller_link</linkName>
+          <propJointName>BL_engine_propeller_joint</propJointName>
+          <engineJointName>BL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>BR_propeller_link</linkName>
+          <propJointName>BR_engine_propeller_joint</propJointName>
+          <engineJointName>BR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FL_propeller_link</linkName>
+          <propJointName>FL_engine_propeller_joint</propJointName>
+          <engineJointName>FL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FR_propeller_link</linkName>
+          <propJointName>FR_engine_propeller_joint</propJointName>
+          <engineJointName>FR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+      </plugin>
+      <plugin name='usv_dynamics_wamv_dynamics_plugin' filename='libusv_gazebo_dynamics_plugin.so'>
+        <bodyName>wamv/base_link</bodyName>
+        <waterLevel>0</waterLevel>
+        <waterDensity>997.8</waterDensity>
+        <xDotU>0.0</xDotU>
+        <yDotV>0.0</yDotV>
+        <nDotR>0.0</nDotR>
+        <xU>51.3</xU>
+        <xUU>72.4</xUU>
+        <yV>40.0</yV>
+        <yVV>0.0</yVV>
+        <zW>500.0</zW>
+        <kP>50.0</kP>
+        <mQ>50.0</mQ>
+        <nR>400.0</nR>
+        <nRR>0.0</nRR>
+        <hullRadius>0.213</hullRadius>
+        <boatWidth>2.4</boatWidth>
+        <boatLength>4.9</boatLength>
+        <length_n>2</length_n>
+        <wave_model>ocean_waves</wave_model>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <frame name='wamv/front_left_cam_to_front_left_cam_link_optical_joint' attached_to='wamv/front_left_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link_optical' attached_to='wamv/front_left_cam_to_front_left_cam_link_optical_joint'/>
+      <frame name='wamv/front_left_cam_post_arm_to_front_left_cam_joint' attached_to='wamv/front_left_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link' attached_to='wamv/front_left_cam_post_arm_to_front_left_cam_joint'/>
+      <frame name='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint' attached_to='wamv/front_left_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_arm_link' attached_to='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_left_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_link' attached_to='wamv/base_to_front_left_cam_post_joint'/>
+      <frame name='wamv/front_right_cam_to_front_right_cam_link_optical_joint' attached_to='wamv/front_right_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link_optical' attached_to='wamv/front_right_cam_to_front_right_cam_link_optical_joint'/>
+      <frame name='wamv/front_right_cam_post_arm_to_front_right_cam_joint' attached_to='wamv/front_right_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link' attached_to='wamv/front_right_cam_post_arm_to_front_right_cam_joint'/>
+      <frame name='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint' attached_to='wamv/front_right_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_arm_link' attached_to='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_right_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_link' attached_to='wamv/base_to_front_right_cam_post_joint'/>
+      <frame name='wamv/velodyne_post_arm_to_velodyne_joint' attached_to='velodyne_post_arm_link'>
+        <pose>0.04 0 0.05 0 0.261799 0</pose>
+      </frame>
+      <frame name='velodyne' attached_to='wamv/velodyne_post_arm_to_velodyne_joint'/>
+      <frame name='wamv/velodyne_post_to_velodyne_post_arm_joint' attached_to='velodyne_post_link'>
+        <pose>0.03 0 0.32675 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_arm_link' attached_to='wamv/velodyne_post_to_velodyne_post_arm_joint'/>
+      <frame name='wamv/base_to_velodyne_post_joint' attached_to='wamv/base_link'>
+        <pose>0.704 0 1.62325 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_link' attached_to='wamv/base_to_velodyne_post_joint'/>
+      <frame name='wamv/dummy_joint' attached_to='wamv/base_link'>
+        <pose>0 0 0 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/dummy_link' attached_to='wamv/dummy_joint'/>
+      <frame name='wamv/hydrophones_pinger_joint' attached_to='wamv/base_link'>
+        <pose>1 0 -1 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/hydrophones' attached_to='wamv/hydrophones_pinger_joint'/>
+      <pose>-532 162 0.1 0 -0 1</pose>
+    </model>
+    <state world_name='vrx_scan_dock_deliver'>
+      <sim_time>96 807000000</sim_time>
+      <real_time>56 332803862</real_time>
+      <wall_time>1725827955 469111661</wall_time>
+      <iterations>29073</iterations>
+      <model name='antenna'>
+        <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='blue_projectile'>
+        <pose>-545 60 0.007601 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-545 60 0.007601 0 -0 0</pose>
+          <velocity>0 0 -0.067262 0 -0 0</velocity>
+          <acceleration>0 0 -0.035161 0 -0 0</acceleration>
+          <wrench>0 0 -0.001406 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_0'>
+        <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-540.743 146.687 1.66777 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-539.972 146.474 1.67444 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-541.727 146.128 1.67569 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-541.531 147.215 1.6548 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-540.049 147.325 1.65735 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_1'>
+        <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-537.569 146.021 1.6782 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-536.798 145.808 1.68302 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-538.553 145.462 1.68831 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-538.357 146.549 1.66717 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-536.875 146.659 1.66628 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_2'>
+        <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-534.497 145.103 1.71632 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-533.726 144.89 1.72031 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-535.481 144.545 1.72896 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-535.285 145.632 1.70558 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-533.803 145.741 1.70217 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ocean_waves'>
+        <pose>1.26646 -4.11833 0 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='ocean_waves_link'>
+          <pose>1.26646 -4.11833 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_0'>
+        <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_1'>
+        <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_2'>
+        <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='sydneyregatta'>
+        <pose>0 0 0.2 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>0 0 0.2 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='wamv'>
+        <pose>-532.09 162.19 -0.054214 0.002015 0.002057 1.00011</pose>
+        <scale>1 1 1</scale>
+        <link name='BL_engine_link'>
+          <pose>-534.058 161.16 0.27021 0.00288 3e-05 1.78551</pose>
+          <velocity>-0.00456 0.001395 -0.031875 0.006288 -0.018201 -0.000227</velocity>
+          <acceleration>-0.008465 -0.004339 -0.201732 0.025903 -0.045928 -0.0001</acceleration>
+          <wrench>-0.126982 -0.065084 -3.02598 0 -0 0</wrench>
+        </link>
+        <link name='BL_propeller_link'>
+          <pose>-534 160.888 -0.23915 0.00288 3e-05 1.78551</pose>
+          <velocity>0.004649 0.004585 -0.032533 0.006288 -0.018201 -0.000227</velocity>
+          <acceleration>0.014197 0.008985 -0.20609 0.026215 -0.044761 -0.000567</acceleration>
+          <wrench>0.007098 0.004492 -0.103045 0 -0 0</wrench>
+        </link>
+        <link name='BR_engine_link'>
+          <pose>-532.206 159.972 0.265776 -3e-05 0.00288 0.214709</pose>
+          <velocity>-0.004689 0.001096 -0.005651 0.006288 -0.018201 -0.000184</velocity>
+          <acceleration>-0.009199 -0.005098 -0.150026 0.025985 -0.044672 0.000143</acceleration>
+          <wrench>-0.137989 -0.076477 -2.25039 0 -0 0</wrench>
+        </link>
+        <link name='BR_propeller_link'>
+          <pose>-532.479 159.912 -0.242792 -3e-05 0.00288 0.214709</pose>
+          <velocity>0.004557 0.004344 -0.010999 0.006288 -0.018201 -0.000184</velocity>
+          <acceleration>0.013642 0.008356 -0.163629 0.026215 -0.044761 -0.000346</acceleration>
+          <wrench>0.006821 0.004178 -0.081815 0 -0 0</wrench>
+        </link>
+        <link name='FL_engine_link'>
+          <pose>-531.754 163.711 0.440618 -3e-05 0.00288 0.214707</pose>
+          <velocity>-0.007211 -8.3e-05 0.026087 0.006288 -0.018201 -0.000178</velocity>
+          <acceleration>-0.016162 -0.010053 -0.031825 0.02597 -0.044676 0.000165</acceleration>
+          <wrench>-0.242425 -0.150802 -0.477373 0 -0 0</wrench>
+        </link>
+        <link name='FL_propeller_link'>
+          <pose>-532.028 163.651 -0.06795 -3e-05 0.00288 0.214707</pose>
+          <velocity>0.002035 0.003164 0.02074 0.006288 -0.018201 -0.000178</velocity>
+          <acceleration>0.006681 0.003394 -0.045428 0.026214 -0.044761 -0.000324</acceleration>
+          <wrench>0.003341 0.001697 -0.022714 0 -0 0</wrench>
+        </link>
+        <link name='FR_engine_link'>
+          <pose>-530.845 163.128 0.438262 0.00288 3e-05 1.78552</pose>
+          <velocity>-0.007271 -0.000228 0.038961 0.006288 -0.018201 -0.000235</velocity>
+          <acceleration>-0.016514 -0.010422 -0.006442 0.025947 -0.045918 -0.000149</acceleration>
+          <wrench>-0.247708 -0.156324 -0.09663 0 -0 0</wrench>
+        </link>
+        <link name='FR_propeller_link'>
+          <pose>-530.788 162.855 -0.071099 0.00288 3e-05 1.78552</pose>
+          <velocity>0.001936 0.002961 0.038303 0.006288 -0.018201 -0.000235</velocity>
+          <acceleration>0.006135 0.002899 -0.0108 0.026215 -0.044761 -0.000618</acceleration>
+          <wrench>0.003067 0.00145 -0.0054 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_base_link'>
+          <pose>-532.047 162.808 1.24527 0.002211 0.001846 1.10011</pose>
+          <velocity>-0.022017 -0.005091 0.015078 0.006288 -0.018201 -0.000173</velocity>
+          <acceleration>-0.0545 -0.032306 -0.069796 0.045334 -0.037805 0.003579</acceleration>
+          <wrench>-0.02725 -0.016153 -0.034898 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_launcher_link'>
+          <pose>-532.056 162.79 1.35319 0.003167 -0.798152 1.09783</pose>
+          <velocity>-0.023984 -0.005768 0.014801 0.006288 -0.018201 -0.000173</velocity>
+          <acceleration>-0.057089 -0.033824 -0.069826 -0.049711 -0.148738 -0.116463</acceleration>
+          <wrench>-0.028545 -0.016912 -0.034913 0 -0 0</wrench>
+        </link>
+        <link name='wamv/base_link'>
+          <pose>-532.09 162.19 -0.054214 0.002015 0.002057 1.00011</pose>
+          <velocity>0.001527 0.003088 0.010415 0.006288 -0.018201 -0.000176</velocity>
+          <acceleration>0.004517 0.002455 -0.085955 -0.301114 -0.26518 -0.005625</acceleration>
+          <wrench>0.8257 0.448811 -15.7131 0 -0 0</wrench>
+        </link>
+        <link name='wamv/imu_wamv_link'>
+          <pose>-532.099 162.485 1.44563 0.002015 0.002057 1.00011</pose>
+          <velocity>-0.02572 -0.006342 0.012102 0.006288 -0.018201 -0.000176</velocity>
+          <acceleration>-0.061365 -0.036178 -0.079774 0.025913 -0.044883 -0.000429</acceleration>
+          <wrench>-0.006137 -0.003618 -0.007977 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ins_link'>
+          <pose>-532.099 162.485 1.44563 0.002015 0.002057 1.00011</pose>
+          <velocity>-0.02572 -0.006342 0.012102 0.006288 -0.018201 -0.000176</velocity>
+          <acceleration>-0.061365 -0.036178 -0.079774 0.026214 -0.044761 -0.000403</acceleration>
+          <wrench>-0.061365 -0.036178 -0.079774 0 -0 0</wrench>
+        </link>
+      </model>
+      <light name='sun'>
+        <pose>0 0 10 0 -0 0</pose>
+      </light>
+    </state>
+  </world>
+</sdf>

--- a/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/right.world
+++ b/NaviGator/simulation/navigator_gazebo/worlds/scan_code_tests/right.world
@@ -1,0 +1,3970 @@
+<sdf version='1.7'>
+  <world name='vrx_scan_dock_deliver'>
+    <scene>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>0</grid>
+      <origin_visual>0</origin_visual>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>1</shadows>
+    </scene>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-33.7242</latitude_deg>
+      <longitude_deg>150.68</longitude_deg>
+      <elevation>0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+    <light name='sun' type='directional'>
+      <cast_shadows>1</cast_shadows>
+      <pose>0 0 10 0 -0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>-453.391 179.995 23.1197 0 0.248344 2.93686</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+    <model name='sydneyregatta'>
+      <pose>0 0 0.2 0 -0 0</pose>
+      <static>1</static>
+      <link name='link'>
+        <visual name='visual_terrain'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Terrain</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_concrete'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>ConcreteDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>DockDark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_metal_galvanized'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>MetalGalvanized</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_dock'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Dock</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_windows_dark'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Windows_Dark</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_roof'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>RoofCorrugated</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_wall'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>Wall</name>
+              </submesh>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='visual_branches'>
+          <geometry>
+            <mesh>
+              <uri>model://sydney_regatta/meshes/sydney_regatta.dae</uri>
+              <submesh>
+                <name>TreeDiffuse</name>
+              </submesh>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://sydney_regatta/materials/scripts/</uri>
+              <uri>model://sydney_regatta/materials/textures/</uri>
+              <name>SydneyTree/Branch</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <mesh>
+              <uri>file://sydney_regatta/meshes/sydney_regatta_shore.dae</uri>
+            </mesh>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_0'>
+      <static>1</static>
+      <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_1'>
+      <static>1</static>
+      <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='post_2'>
+      <static>1</static>
+      <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://post/meshes/post.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='antenna'>
+      <static>1</static>
+      <link name='base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>file://antenna/meshes/antenna.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.95 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.35</radius>
+              <length>1.9</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+    </model>
+    <model name='ground_station_0'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+    </model>
+    <model name='ground_station_1'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+    </model>
+    <model name='ground_station_2'>
+      <static>1</static>
+      <frame name='tent::__model__' attached_to='tent::base_link'>
+        <pose relative_to='__model__'>0 0 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='tent::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://tent/mesh/tent.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>3 3 3</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='tent::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_a::__model__' attached_to='table_a::base_link'>
+        <pose relative_to='__model__'>0.5 0.9 0 0 -0 0</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='table_b::__model__' attached_to='table_b::base_link'>
+        <pose relative_to='__model__'>1 -0.5 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='table_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <uri>model://foldable_table/mesh/foldable_table.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0 0.35 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.82 0.74 0.67</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='table_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_a::__model__' attached_to='chair_a::base_link'>
+        <pose relative_to='__model__'>0.2 0 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_a::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_a::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_b::__model__' attached_to='chair_b::base_link'>
+        <pose relative_to='__model__'>0.2 -0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_b::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_b::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <frame name='chair_c::__model__' attached_to='chair_c::base_link'>
+        <pose relative_to='__model__'>-0.6 0.8 0 0 -0 1.57</pose>
+      </frame>
+      <static>1</static>
+      <link name='chair_c::base_link'>
+        <visual name='visual'>
+          <geometry>
+            <mesh>
+              <scale>0.1 0.1 0.1</scale>
+              <uri>model://foldable_chair/mesh/foldable_chair.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <pose>0 0.05 0.4 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.8</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <pose relative_to='chair_c::__model__'>0 0 0 0 -0 0</pose>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+    </model>
+    <model name='blue_projectile'>
+      <link name='link'>
+        <inertial>
+          <mass>0.04</mass>
+          <inertia>
+            <ixx>2.166e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2166</iyy>
+            <iyz>0</iyz>
+            <izz>2166</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://blue_projectile/materials/scripts/blue_projectile.material</uri>
+              <name>blue_projectile/Blue</name>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name='buoyancy_sphere'>
+          <link_name>link</link_name>
+          <pose>0 0 -0.02 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+      </plugin>
+      <pose>-545 60 0.03 0 -0 0</pose>
+    </model>
+    <model name='ocean_waves'>
+      <static>1</static>
+      <plugin name='ocean_waves::wavefield_entity' filename='libWavefieldModelPlugin.so'>
+        <static>0</static>
+        <update_rate>30</update_rate>
+        <size>1000 1000</size>
+        <cell_count>50 50</cell_count>
+        <wave>
+          <model>PMS</model>
+          <period>5</period>
+          <number>3</number>
+          <scale>2.5</scale>
+          <gain>0.1</gain>
+          <direction>1.0 0.0</direction>
+          <angle>0.4</angle>
+          <tau>2.0</tau>
+          <amplitude>0.0</amplitude>
+          <steepness>0.0</steepness>
+        </wave>
+      </plugin>
+      <link name='ocean_waves_link'>
+        <visual name='ocean_waves_visual'>
+          <plugin name='ocean_waves_visual_plugin' filename='libWavefieldVisualPlugin.so'>
+            <enableRtt>1</enableRtt>
+            <rttNoise>0.1</rttNoise>
+            <refractOpacity>0.2</refractOpacity>
+            <reflectOpacity>0.2</reflectOpacity>
+            <wave>
+              <model>PMS</model>
+              <period>5</period>
+              <number>3</number>
+              <scale>2.5</scale>
+              <gain>0.1</gain>
+              <direction>1.0 0.0</direction>
+              <angle>0.4</angle>
+              <tau>2.0</tau>
+              <amplitude>0.0</amplitude>
+              <steepness>0.0</steepness>
+            </wave>
+          </plugin>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <visual name='ocean_waves_below_visual'>
+          <pose>0 0 -0.05 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>2.5 2.5 1</scale>
+              <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
+            </mesh>
+          </geometry>
+          <material>
+            <script>
+              <uri>model://ocean_waves/materials/scripts/waves.material</uri>
+              <name>WaveSim/GerstnerWaves</name>
+            </script>
+          </material>
+          <laser_retro>-1</laser_retro>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <plugin name='wind' filename='libusv_gazebo_wind_plugin.so'>
+      <wind_obj>
+        <name>wamv</name>
+        <link_name>wamv/base_link</link_name>
+        <coeff_vector>.5 .5 .33</coeff_vector>
+      </wind_obj>
+      <wind_direction>270</wind_direction>
+      <wind_mean_velocity>0</wind_mean_velocity>
+      <var_wind_gain_constants>0</var_wind_gain_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
+      <random_seed/>
+      <update_rate>10</update_rate>
+      <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
+      <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+    </plugin>
+    <model name='robotx_light_buoy'>
+      <pose>-511 218 0.25 0 -0 3.14</pose>
+      <link name='base_link'>
+        <inertial>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <mass>67.15</mass>
+          <inertia>
+            <ixx>13.486</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>13.486</iyy>
+            <iyz>0</iyz>
+            <izz>25.1813</izz>
+          </inertia>
+        </inertial>
+        <visual name='base'>
+          <geometry>
+            <mesh>
+              <uri>file://robotx_light_buoy/mesh/robotx_light_buoy.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='panel_1'>
+          <pose>-0.05 0.09 1.3 0 -0 0.5</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+          <plugin name='lightplugin' filename='liblight_buoy_plugin.so'>
+            <color_1>off</color_1>
+            <color_2>off</color_2>
+            <color_3>off</color_3>
+            <visuals>
+              <visual>robotx_light_buoy::base_link::panel_1</visual>
+              <visual>robotx_light_buoy::base_link::panel_2</visual>
+              <visual>robotx_light_buoy::base_link::panel_3</visual>
+            </visuals>
+            <robot_namespace>vrx</robot_namespace>
+            <topic>light_buoy/shuffle</topic>
+          </plugin>
+        </visual>
+        <visual name='panel_2'>
+          <pose>-0.06 -0.085 1.3 0 0 -0.54719</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <visual name='panel_3'>
+          <pose>0.11 -0.003 1.3 0 -0 1.5472</pose>
+          <geometry>
+            <box>
+              <size>0.192 0.01 0.386</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+        </visual>
+        <collision name='collision_base'>
+          <pose>0 0 -0.2 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='collision_body'>
+          <pose>0 0 0.85 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.4</radius>
+              <length>1.75</length>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='BuoyancyPlugin' filename='libbuoyancy_gazebo_plugin.so'>
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>1000.0</linear_drag>
+        <angular_drag>200.0</angular_drag>
+        <buoyancy name='buoyancy_base'>
+          <link_name>base_link</link_name>
+          <pose>0 0 -0.2 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <buoyancy name='buoyancy_body'>
+          <link_name>base_link</link_name>
+          <pose>0 0 0.8 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.15</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+      </plugin>
+    </model>
+    <plugin name='contain_placard1_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard1_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard1_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard2_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard2_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_big_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_big_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.5 0.5 0.5</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='contain_placard3_small_plugin' filename='libContainPlugin.so'>
+      <enabled>1</enabled>
+      <entity>blue_projectile::link</entity>
+      <namespace>vrx/dock_2022_placard3_small_hole</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::link_symbols'>-0.6 -0.27 1.33 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.25 0.5 0.25</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='scan_dock__deliver_scoring_plugin' filename='libscan_dock_scoring_plugin.so'>
+      <vehicle>wamv</vehicle>
+      <task_name>scan_dock_deliver</task_name>
+      <initial_state_duration>3</initial_state_duration>
+      <ready_state_duration>3</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <robot_namespace>vrx</robot_namespace>
+      <color_sequence_service>scan_dock_deliver/color_sequence</color_sequence_service>
+      <color_1>blue</color_1>
+      <color_2>green</color_2>
+      <color_3>red</color_3>
+      <dock_bonus_points>15</dock_bonus_points>
+      <correct_dock_bonus_points>5</correct_dock_bonus_points>
+      <bays>
+        <bay>
+          <name>bay1</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>red_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay2</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>1</dock_allowed>
+          <symbol>blue_circle</symbol>
+        </bay>
+        <bay>
+          <name>bay3</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <dock_allowed>0</dock_allowed>
+          <symbol>yellow_rectangle</symbol>
+        </bay>
+      </bays>
+      <targets>
+        <target>
+          <topic>vrx/dock_2022_placard1_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard1_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard2_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>vrx/dock_2022_placard3_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+      </targets>
+    </plugin>
+    <plugin name='vehicle_docked_bay1' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay1_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_1_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard1::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay2_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_2_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard2::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -4.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>1.5 4 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <plugin name='vehicle_docked_bay3_exterior' filename='libContainPlugin.so'>
+      <entity>wamv::wamv/base_link</entity>
+      <namespace>vrx/dock_2022/bay_3_external</namespace>
+      <pose frame='robotx_dock_2022::dock_2022_placard3::placard::link'>0 -9.5 -1.5 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>5.5 1.5 2</size>
+        </box>
+      </geometry>
+    </plugin>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+    <physics type='ode'>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+    </physics>
+    <wind/>
+    <model name='wamv'>
+      <link name='wamv/base_link'>
+        <inertial>
+          <pose>0.012722 0 0.026171 0 -0 0</pose>
+          <mass>182.806</mass>
+          <inertia>
+            <ixx>128.232</ixx>
+            <ixy>-2.4178e-21</ixy>
+            <ixz>-3.85993</ixz>
+            <iyy>403.15</iyy>
+            <iyz>-9.28107e-22</iyz>
+            <izz>447.942</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_collision_collision'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_collision_collision_1'>
+          <pose>0.95 0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_lens_collision_collision_2'>
+          <pose>0.987607 0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_cam_box_collision_collision_3'>
+          <pose>0.949948 0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_collision_collision_4'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_collision_collision_5'>
+          <pose>0.95 -0.1 1.473 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_lens_collision_collision_6'>
+          <pose>0.987607 -0.1 1.49626 3.14159 1.36136 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.042</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_cam_box_collision_collision_7'>
+          <pose>0.949948 -0.1 1.50426 0 0.20944 0</pose>
+          <geometry>
+            <box>
+              <size>0.036 0.03 0.03</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_collision_collision_8'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_collision_collision_9'>
+          <pose>0.734 0 1.95 -1.20428 -0 -1.5708</pose>
+          <geometry>
+            <cylinder>
+              <length>0.065</length>
+              <radius>0.008</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__velodyne_collision_collision_10'>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.075</length>
+              <radius>0.055</radius>
+            </cylinder>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <friction>
+              <ode/>
+              <torsional>
+                <ode/>
+              </torsional>
+            </friction>
+            <bounce/>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_float_collision_11'>
+          <pose>-0.4 1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_mid_float_collision_12'>
+          <pose>1.85 1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_front_float_collision_13'>
+          <pose>2.3 1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_lower_collision_14'>
+          <pose>0.9 0.85 1 0.78 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_left_beam_upper_collision_15'>
+          <pose>0.9 0.6 1.18 1.35 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_lower_collision_16'>
+          <pose>-0.65 0.99 0.7 0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_medium_collision_17'>
+          <pose>-0.57 0.87 1.05 0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_left_beam_upper_collision_18'>
+          <pose>-0.55 0.65 1.17 1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_lower_collision_19'>
+          <pose>-0.74 1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_medium_collision_20'>
+          <pose>-0.79 0.91 1.05 0.75 -0.15 -0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_left_beam_upper_collision_21'>
+          <pose>-0.81 0.67 1.18 1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__left_joint_collision_22'>
+          <pose>0.58 1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_float_collision_23'>
+          <pose>-0.4 -1.03 0.2 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>4</length>
+              <radius>0.2</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_mid_float_collision_24'>
+          <pose>1.85 -1.03 0.3 0 1.38 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.17</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_front_float_collision_25'>
+          <pose>2.3 -1.03 0.4 0 1.3 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.12</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_lower_collision_26'>
+          <pose>0.9 -0.85 1 -0.78 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.5</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__front_right_beam_upper_collision_27'>
+          <pose>0.9 -0.6 1.18 -1.35 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.2</length>
+              <radius>0.04</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_lower_collision_28'>
+          <pose>-0.65 -0.99 0.7 -0.1 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_medium_collision_29'>
+          <pose>-0.57 -0.87 1.05 -0.75 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__mid_right_beam_upper_collision_30'>
+          <pose>-0.55 -0.65 1.17 -1.35 0.25 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_lower_collision_31'>
+          <pose>-0.74 -1.03 0.7 0 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.45</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_medium_collision_32'>
+          <pose>-0.79 -0.91 1.05 -0.75 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.32</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__rear_right_beam_upper_collision_33'>
+          <pose>-0.81 -0.67 1.18 -1.45 -0.15 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.3</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__right_joint_collision_34'>
+          <pose>0.58 -1.03 0.6 0 -0.6 0</pose>
+          <geometry>
+            <box>
+              <size>0.65 0.2 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__top_base_collision_35'>
+          <pose>0 0 1.25 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>1.85 1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/base_link_fixed_joint_lump__hydrophones_collision_collision_36'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_left_cam_post_link_visual'>
+          <pose>0.92 0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_post_arm_visual_visual_1'>
+          <pose>0.912 0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_left_cam_visual_visual_2'>
+          <pose>0.937721 0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/front_right_cam_post_link_visual_3'>
+          <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1765</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_post_arm_visual_visual_4'>
+          <pose>0.912 -0.1 1.47 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__front_right_cam_visual_visual_5'>
+          <pose>0.937721 -0.1 1.50686 0.20944 -0 1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/mono_camera/mesh/mono_camera.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_link_visual_6'>
+          <pose>0.704 0 1.62325 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.6535</length>
+              <radius>0.0076</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_post_arm_visual_visual_7'>
+          <pose>0.696 0 1.947 -1.0472 -0 -1.5708</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__velodyne_visual_visual_8'>
+          <pose>0.764941 0 1.96619 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/3d_lidar/mesh/3d_lidar.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/dummy_link_visual_9'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/WAM-V-Base/mesh/WAM-V-Base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <visual name='wamv/base_link_fixed_joint_lump__wamv/hydrophones_visual_10'>
+          <pose>1 0 -1 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name='front_left_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_left_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_left_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_left_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_left_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='front_right_cam_sensor' type='camera'>
+          <update_rate>30</update_rate>
+          <camera name='front_right_cam_camera'>
+            <horizontal_fov>1.39626</horizontal_fov>
+            <image>
+              <width>1280</width>
+              <height>720</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name='camera_plugin_front_right_cam' filename='libgazebo_ros_camera.so'>
+            <alwaysOn>1</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>wamv/sensors/camera/front_right_cam</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>wamv/front_right_cam_link_optical</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.97 -0.1 1.5 0 0.20944 0</pose>
+        </sensor>
+        <sensor name='velodyne_sensor' type='gpu_ray'>
+          <update_rate>10</update_rate>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>18750</samples>
+                <resolution>0.1</resolution>
+                <min_angle>-3.14159</min_angle>
+                <max_angle>3.14159</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>16</samples>
+                <resolution>1</resolution>
+                <min_angle>-0.261799</min_angle>
+                <max_angle>0.261799</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>0.1</min>
+              <max>130</max>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.01</stddev>
+            </noise>
+          </ray>
+          <plugin name='velodyne_plugin' filename='libgazebo_ros_velodyne_gpu_laser.so'>
+            <topicName>velodyne_points</topicName>
+            <frameName>velodyne</frameName>
+            <min_intensity>0</min_intensity>
+            <robotNamespace>/</robotNamespace>
+          </plugin>
+          <pose>0.774 0 2 0 0.261799 0</pose>
+        </sensor>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 1.1 0.318237 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_engine_link'>
+        <pose relative_to='BL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BL_engine_link_fixed_joint_lump__BL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BL_engine_link</parent>
+        <child>BL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BL_propeller_link'>
+        <pose relative_to='BL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BL_propeller_link_fixed_joint_lump__BL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>-1.9304 -1.1 0.318237 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>BR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_engine_link'>
+        <pose relative_to='BR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='BR_engine_link_fixed_joint_lump__BR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='BR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='BR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>BR_engine_link</parent>
+        <child>BR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='BR_propeller_link'>
+        <pose relative_to='BR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='BR_propeller_link_fixed_joint_lump__BR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='BR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 0.54 0.49675 0 0 -0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FL_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_engine_link'>
+        <pose relative_to='FL_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FL_engine_link_fixed_joint_lump__FL_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FL_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FL_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FL_engine_link</parent>
+        <child>FL_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FL_propeller_link'>
+        <pose relative_to='FL_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FL_propeller_link_fixed_joint_lump__FL_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FL_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_chasis_engine_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>1.46 -0.54 0.49657 0 -0 0.785398</pose>
+        <parent>wamv/base_link</parent>
+        <child>FR_engine_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-3.14159</lower>
+            <upper>3.14159</upper>
+            <effort>10</effort>
+            <velocity>10</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_engine_link'>
+        <pose relative_to='FR_chasis_engine_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>15</mass>
+          <inertia>
+            <ixx>0.889245</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.911125</iyy>
+            <iyz>0</iyz>
+            <izz>0.078125</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_vertical_axis_collision_collision'>
+          <pose>-0.16 0 -0.24 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.15 0.83</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='FR_engine_link_fixed_joint_lump__FR_engine_rear_end_collision_collision_1'>
+          <pose>-0.34 0 0.12 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.12 0.15 0.12</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_engine_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/engine/mesh/engine.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='FR_engine_propeller_joint' type='revolute'>
+        <pose relative_to='FR_engine_link'>-0.278156 0 -0.509371 0 -0 0</pose>
+        <parent>FR_engine_link</parent>
+        <child>FR_propeller_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>400</effort>
+            <velocity>100</velocity>
+            <lower>-1e+16</lower>
+            <upper>1e+16</upper>
+          </limit>
+          <dynamics>
+            <damping>0.05</damping>
+            <friction>0.05</friction>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='FR_propeller_link'>
+        <pose relative_to='FR_engine_propeller_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.008545</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.008545</iyy>
+            <iyz>0</iyz>
+            <izz>0.0144</izz>
+          </inertia>
+        </inertial>
+        <collision name='FR_propeller_link_fixed_joint_lump__FR_propeller_collision_collision'>
+          <pose>-0.08 0 0 3.14159 1.57079 3.14159</pose>
+          <geometry>
+            <cylinder>
+              <length>0.18</length>
+              <radius>0.24</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='FR_propeller_link_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_description/models/propeller/mesh/propeller.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_base_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.54 0.3 1.3 0 -0 0.1</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ball_shooter_base_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_base_link'>
+        <pose relative_to='wamv/ball_shooter_base_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>-0.02 0 0.05 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00083</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00052083</iyy>
+            <iyz>0</iyz>
+            <izz>0.00052083</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/ball_shooter_base_link_fixed_joint_lump__ball_shooter_base_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_base.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ball_shooter_launcher_joint' type='revolute'>
+        <pose relative_to='wamv/ball_shooter_base_link'>-0.0204 0 0.107877 0 -0.8 0</pose>
+        <parent>wamv/ball_shooter_base_link</parent>
+        <child>wamv/ball_shooter_launcher_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ball_shooter_launcher_link'>
+        <pose relative_to='wamv/ball_shooter_launcher_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 3.14159 -1.57079 3.14159</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.00177917</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00177917</iyy>
+            <iyz>0</iyz>
+            <izz>0.000225</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_collision_collision'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <box>
+              <size>0.3 0.3 0.2</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ball_shooter_launcher_link_fixed_joint_lump__ball_shooter_launcher_visual_visual'>
+          <pose>0 0 0 0 0.261799 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/vrx_gazebo/models/ball_shooter/meshes/ball_shooter_launcher.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/imu_wamv_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/imu_wamv_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/imu_wamv_link'>
+        <pose relative_to='wamv/imu_wamv_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>0.1</mass>
+          <inertia>
+            <ixx>8.3e-05</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>8.3e-05</iyy>
+            <iyz>0</iyz>
+            <izz>0.0125</izz>
+          </inertia>
+        </inertial>
+        <visual name='wamv/imu_wamv_link_fixed_joint_lump__imu_wamv_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <box>
+              <size>0.05 0.025 0.005</size>
+            </box>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='wamv/ins_joint' type='revolute'>
+        <pose relative_to='wamv/base_link'>0.24 0.17 1.5 0 -0 0</pose>
+        <parent>wamv/base_link</parent>
+        <child>wamv/ins_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>1000</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name='wamv/ins_link'>
+        <pose relative_to='wamv/ins_joint'>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.006458</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.006458</iyy>
+            <iyz>0</iyz>
+            <izz>0.01125</izz>
+          </inertia>
+        </inertial>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_base_collision'>
+          <pose>0 0 0.025 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.05</length>
+              <radius>0.015</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <collision name='wamv/ins_link_fixed_joint_lump__ins_collision_antenna_collision_1'>
+          <pose>0 0 0.11 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.15</radius>
+            </cylinder>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='wamv/ins_link_fixed_joint_lump__ins_visual_visual'>
+          <pose>0 0 0 0 -0 0</pose>
+          <geometry>
+            <mesh>
+              <scale>1 1 1</scale>
+              <uri>/home/hoshbosh/catkin_ws/src/mil/NaviGator/simulation/VRX/vrx/wamv_gazebo/models/gps/mesh/gps.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <plugin name='gps_plugin_ins' filename='libhector_gazebo_ros_gps.so'>
+        <updateRate>15</updateRate>
+        <alwaysOn>1</alwaysOn>
+        <bodyName>wamv/ins_link</bodyName>
+        <frameId>wamv/ins_link</frameId>
+        <topicName>wamv/sensors/gps/gps/fix</topicName>
+        <velocityTopicName>wamv/sensors/gps/gps/fix_velocity</velocityTopicName>
+        <useWorldSphericalCoordinates>1</useWorldSphericalCoordinates>
+        <offset>0.0 0.0 0.0</offset>
+        <drift>0.0 0.0 0.0</drift>
+        <gaussianNoise>0 0 0</gaussianNoise>
+        <velocityOffset>0.0 0.0 0.0</velocityOffset>
+        <velocityDrift>0.0 0.0 0.0</velocityDrift>
+        <velocityGaussianNoise>0.0 0.0 0.0</velocityGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='imu_plugin_imu_wamv' filename='libhector_gazebo_ros_imu.so'>
+        <updateRate>15</updateRate>
+        <bodyName>wamv/imu_wamv_link</bodyName>
+        <topicName>wamv/sensors/imu/imu/data</topicName>
+        <serviceName>wamv/sensors/imu_service</serviceName>
+        <frameId>wamv/imu_wamv_link</frameId>
+        <alwaysOn>1</alwaysOn>
+        <accelOffset>0.0 0.0 0.0</accelOffset>
+        <accelDrift>0.0 0.0 0.0</accelDrift>
+        <accelDriftFrequency>0.00027 0.00027 0.000027</accelDriftFrequency>
+        <accelGaussianNoise>0.0 0.0 0.0</accelGaussianNoise>
+        <rateOffset>0.0 0.0 0.0</rateOffset>
+        <rateDrift>0.0 0.0 0.0</rateDrift>
+        <rateDriftFrequency>0.00027 0.00027 0.000027</rateDriftFrequency>
+        <rateGaussianNoise>0.0 0.0 0.0</rateGaussianNoise>
+        <yawOffset>0.0</yawOffset>
+        <yawDrift>0.0</yawDrift>
+        <yawDriftFrequency>0.00027</yawDriftFrequency>
+        <yawGaussianNoise>0.0</yawGaussianNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='ball_shooter_plugin' filename='libball_shooter_plugin.so'>
+        <projectile>
+          <model_name>blue_projectile</model_name>
+          <link_name>link</link_name>
+          <frame>wamv/ball_shooter_launcher_link</frame>
+          <pose>0.14 0 0 0 0 0</pose>
+        </projectile>
+        <num_shots>4</num_shots>
+        <shot_force>300</shot_force>
+        <topic>wamv/shooters/ball_shooter/fire</topic>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='pinger_plugin' filename='libusv_gazebo_acoustic_pinger_plugin.so'>
+        <frameId>wamv/pinger</frameId>
+        <topicName>wamv/sensors/pingers/hydrophones/range_bearing</topicName>
+        <setPositionTopicName>wamv/sensors/pingers/hydrophones/set_pinger_position</setPositionTopicName>
+        <rangeNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>3.0</stddev>
+          </noise>
+        </rangeNoise>
+        <bearingNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </bearingNoise>
+        <elevationNoise>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </elevationNoise>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <plugin name='wamv_gazebo_thrust' filename='libusv_gazebo_thrust_plugin.so'>
+        <cmdTimeout>1.0</cmdTimeout>
+        <robotNamespace>wamv</robotNamespace>
+        <thruster>
+          <linkName>BL_propeller_link</linkName>
+          <propJointName>BL_engine_propeller_joint</propJointName>
+          <engineJointName>BL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>BR_propeller_link</linkName>
+          <propJointName>BR_engine_propeller_joint</propJointName>
+          <engineJointName>BR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/BR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/BR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FL_propeller_link</linkName>
+          <propJointName>FL_engine_propeller_joint</propJointName>
+          <engineJointName>FL_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FL_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FL_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+        <thruster>
+          <linkName>FR_propeller_link</linkName>
+          <propJointName>FR_engine_propeller_joint</propJointName>
+          <engineJointName>FR_chasis_engine_joint</engineJointName>
+          <cmdTopic>thrusters/FR_thrust_cmd</cmdTopic>
+          <angleTopic>thrusters/FR_thrust_angle</angleTopic>
+          <enableAngle>1</enableAngle>
+          <mappingType>1</mappingType>
+          <maxCmd>1.0</maxCmd>
+          <maxForceFwd>250.0</maxForceFwd>
+          <maxForceRev>-100.0</maxForceRev>
+          <maxAngle>1.5707963267948966</maxAngle>
+        </thruster>
+      </plugin>
+      <plugin name='usv_dynamics_wamv_dynamics_plugin' filename='libusv_gazebo_dynamics_plugin.so'>
+        <bodyName>wamv/base_link</bodyName>
+        <waterLevel>0</waterLevel>
+        <waterDensity>997.8</waterDensity>
+        <xDotU>0.0</xDotU>
+        <yDotV>0.0</yDotV>
+        <nDotR>0.0</nDotR>
+        <xU>51.3</xU>
+        <xUU>72.4</xUU>
+        <yV>40.0</yV>
+        <yVV>0.0</yVV>
+        <zW>500.0</zW>
+        <kP>50.0</kP>
+        <mQ>50.0</mQ>
+        <nR>400.0</nR>
+        <nRR>0.0</nRR>
+        <hullRadius>0.213</hullRadius>
+        <boatWidth>2.4</boatWidth>
+        <boatLength>4.9</boatLength>
+        <length_n>2</length_n>
+        <wave_model>ocean_waves</wave_model>
+        <robotNamespace>/</robotNamespace>
+      </plugin>
+      <frame name='wamv/front_left_cam_to_front_left_cam_link_optical_joint' attached_to='wamv/front_left_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link_optical' attached_to='wamv/front_left_cam_to_front_left_cam_link_optical_joint'/>
+      <frame name='wamv/front_left_cam_post_arm_to_front_left_cam_joint' attached_to='wamv/front_left_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_link' attached_to='wamv/front_left_cam_post_arm_to_front_left_cam_joint'/>
+      <frame name='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint' attached_to='wamv/front_left_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_arm_link' attached_to='wamv/front_left_cam_post_to_front_left_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_left_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_left_cam_post_link' attached_to='wamv/base_to_front_left_cam_post_joint'/>
+      <frame name='wamv/front_right_cam_to_front_right_cam_link_optical_joint' attached_to='wamv/front_right_cam_link'>
+        <pose>0 0 0 -1.5708 -0 -1.5708</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link_optical' attached_to='wamv/front_right_cam_to_front_right_cam_link_optical_joint'/>
+      <frame name='wamv/front_right_cam_post_arm_to_front_right_cam_joint' attached_to='wamv/front_right_cam_post_arm_link'>
+        <pose>0.02 0 0.027 0 0.20944 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_link' attached_to='wamv/front_right_cam_post_arm_to_front_right_cam_joint'/>
+      <frame name='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint' attached_to='wamv/front_right_cam_post_link'>
+        <pose>0.03 0 0.08825 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_arm_link' attached_to='wamv/front_right_cam_post_to_front_right_cam_post_arm_joint'/>
+      <frame name='wamv/base_to_front_right_cam_post_joint' attached_to='wamv/base_link'>
+        <pose>0.92 -0.1 1.38475 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/front_right_cam_post_link' attached_to='wamv/base_to_front_right_cam_post_joint'/>
+      <frame name='wamv/velodyne_post_arm_to_velodyne_joint' attached_to='velodyne_post_arm_link'>
+        <pose>0.04 0 0.05 0 0.261799 0</pose>
+      </frame>
+      <frame name='velodyne' attached_to='wamv/velodyne_post_arm_to_velodyne_joint'/>
+      <frame name='wamv/velodyne_post_to_velodyne_post_arm_joint' attached_to='velodyne_post_link'>
+        <pose>0.03 0 0.32675 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_arm_link' attached_to='wamv/velodyne_post_to_velodyne_post_arm_joint'/>
+      <frame name='wamv/base_to_velodyne_post_joint' attached_to='wamv/base_link'>
+        <pose>0.704 0 1.62325 0 -0 0</pose>
+      </frame>
+      <frame name='velodyne_post_link' attached_to='wamv/base_to_velodyne_post_joint'/>
+      <frame name='wamv/dummy_joint' attached_to='wamv/base_link'>
+        <pose>0 0 0 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/dummy_link' attached_to='wamv/dummy_joint'/>
+      <frame name='wamv/hydrophones_pinger_joint' attached_to='wamv/base_link'>
+        <pose>1 0 -1 0 -0 0</pose>
+      </frame>
+      <frame name='wamv/hydrophones' attached_to='wamv/hydrophones_pinger_joint'/>
+      <pose>-532 162 0.1 0 -0 1</pose>
+    </model>
+    <state world_name='vrx_scan_dock_deliver'>
+      <sim_time>192 351000000</sim_time>
+      <real_time>270 451940036</real_time>
+      <wall_time>1725827544 842863757</wall_time>
+      <iterations>124617</iterations>
+      <model name='antenna'>
+        <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-531.064 147.669 1.59471 -0.068142 0 -0.1</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='blue_projectile'>
+        <pose>-545 60 -0.010203 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-545 60 -0.010203 0 -0 0</pose>
+          <velocity>0 0 0.001779 0 -0 0</velocity>
+          <acceleration>0 0 -0.009644 0 -0 0</acceleration>
+          <wrench>0 0 -0.000386 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_0'>
+        <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-540.743 146.687 1.66777 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-539.972 146.474 1.67444 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-541.727 146.128 1.67569 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-541.531 147.215 1.6548 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-540.049 147.325 1.65735 0.018234 0.008353 2.87188</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-540.796 146.494 1.67142 -0.00834 0.01824 1.30173</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_1'>
+        <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-537.569 146.021 1.6782 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-536.798 145.808 1.68302 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-538.553 145.462 1.68831 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-538.357 146.549 1.66717 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-536.875 146.659 1.66628 0.018663 0.006044 2.87168</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-537.623 145.828 1.68193 -0.00603 0.018667 1.30157</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ground_station_2'>
+        <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+        <scale>1 1 1</scale>
+        <link name='chair_a::base_link'>
+          <pose>-534.497 145.103 1.71632 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_b::base_link'>
+          <pose>-533.726 144.89 1.72031 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='chair_c::base_link'>
+          <pose>-535.481 144.545 1.72896 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_a::base_link'>
+          <pose>-535.285 145.632 1.70558 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='table_b::base_link'>
+          <pose>-533.803 145.741 1.70217 0.020794 0.005009 2.8716</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+        <link name='tent::base_link'>
+          <pose>-534.551 144.91 1.72047 -0.004994 0.020798 1.30149</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='ocean_waves'>
+        <pose>6.80666 -14.7297 0 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='ocean_waves_link'>
+          <pose>6.80666 -14.7297 0 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_0'>
+        <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-535.917 154.363 0.675884 -0.17182 0.030464 -0.005286</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_1'>
+        <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-527.49 153.855 0.425844 -0.1365 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='post_2'>
+        <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-544.833 156.672 0.499025 -0.162625 0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='robotx_light_buoy'>
+        <pose>-509.344 195.549 0.332585 0 -0 3.14</pose>
+        <scale>1 1 1</scale>
+        <link name='base_link'>
+          <pose>-509.344 195.549 0.332585 0 -0 3.14</pose>
+          <velocity>0 0 -0.01533 0 -0 0</velocity>
+          <acceleration>0 0 0.016998 0 -0 0</acceleration>
+          <wrench>0 0 1.14139 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='sydneyregatta'>
+        <pose>0 0 0.2 0 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>0 0 0.2 0 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 0 0 0 -0 0</acceleration>
+          <wrench>0 0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='wamv'>
+        <pose>-524.133 201.207 -0.05872 0.002999 -0.001082 1.00036</pose>
+        <scale>1 1 1</scale>
+        <link name='BL_engine_link'>
+          <pose>-526.101 200.175 0.260726 0.001356 -0.002886 1.78577</pose>
+          <velocity>-0.00631 0.000445 -0.031218 0.011337 -0.025232 -0.000341</velocity>
+          <acceleration>0.003669 0.005947 -0.043576 -0.026966 0.013823 -0.001279</acceleration>
+          <wrench>0.05503 0.089203 -0.653634 0 -0 0</wrench>
+        </link>
+        <link name='BL_propeller_link'>
+          <pose>-526.043 199.905 -0.249445 0.001356 -0.002886 1.78577</pose>
+          <velocity>0.006471 0.006209 -0.032812 0.011337 -0.025232 -0.000341</velocity>
+          <acceleration>-0.003233 -0.008134 -0.036509 -0.027595 0.013439 -0.000285</acceleration>
+          <wrench>-0.001617 -0.004067 -0.018255 0 -0 0</wrench>
+        </link>
+        <link name='BR_engine_link'>
+          <pose>-524.249 198.987 0.254128 0.002886 0.001356 0.214976</pose>
+          <velocity>-0.00646 2.5e-05 0.002035 0.011337 -0.025232 -0.000266</velocity>
+          <acceleration>0.002604 0.005174 -0.035692 -0.027426 0.013238 -0.000859</acceleration>
+          <wrench>0.039059 0.077611 -0.535383 0 -0 0</wrench>
+        </link>
+        <link name='BR_propeller_link'>
+          <pose>-524.522 198.929 -0.254864 0.002886 0.001356 0.214976</pose>
+          <velocity>0.006367 0.005868 -0.005505 0.011337 -0.025232 -0.000266</velocity>
+          <acceleration>-0.004044 -0.008791 -0.030034 -0.027595 0.013439 4.9e-05</acceleration>
+          <wrench>-0.002022 -0.004396 -0.015017 0 -0 0</wrench>
+        </link>
+        <link name='FL_engine_link'>
+          <pose>-523.798 202.726 0.441227 0.002886 0.001356 0.214977</pose>
+          <velocity>-0.010181 -0.002216 0.055796 0.011337 -0.025232 -0.00025</velocity>
+          <acceleration>0.004188 0.009674 -0.145032 -0.027415 0.013222 -0.000952</acceleration>
+          <wrench>0.062821 0.145103 -2.17548 0 -0 0</wrench>
+        </link>
+        <link name='FL_propeller_link'>
+          <pose>-524.071 202.668 -0.067764 0.002886 0.001356 0.214977</pose>
+          <velocity>0.002647 0.003623 0.048256 0.011337 -0.025232 -0.00025</velocity>
+          <acceleration>-0.002466 -0.004266 -0.139374 -0.027596 0.013439 -4.5e-05</acceleration>
+          <wrench>-0.001233 -0.002133 -0.069687 0 -0 0</wrench>
+        </link>
+        <link name='FR_engine_link'>
+          <pose>-522.889 202.143 0.437808 0.001356 -0.002886 1.78577</pose>
+          <velocity>-0.010251 -0.00242 0.07212 0.011337 -0.025232 -0.000368</velocity>
+          <acceleration>0.003663 0.009289 -0.141162 -0.026967 0.013827 -0.001189</acceleration>
+          <wrench>0.054944 0.139338 -2.11742 0 -0 0</wrench>
+        </link>
+        <link name='FR_propeller_link'>
+          <pose>-522.831 201.872 -0.072363 0.001356 -0.002886 1.78577</pose>
+          <velocity>0.002522 0.003342 0.070526 0.011337 -0.025232 -0.000368</velocity>
+          <acceleration>-0.003215 -0.004787 -0.134096 -0.027595 0.013439 -0.000195</acceleration>
+          <wrench>-0.001607 -0.002393 -0.067048 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_base_link'>
+          <pose>-524.092 201.82 1.24276 0.002876 -0.001376 1.10036</pose>
+          <velocity>-0.030648 -0.011224 0.038126 0.011337 -0.025232 -0.000268</velocity>
+          <acceleration>0.015982 0.033415 -0.116135 -0.042628 0.016079 0.000123</acceleration>
+          <wrench>0.007991 0.016708 -0.058067 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ball_shooter_launcher_link'>
+          <pose>-524.101 201.801 1.35061 0.004134 -0.801372 1.09739</pose>
+          <velocity>-0.033374 -0.012445 0.037689 0.011337 -0.025232 -0.000268</velocity>
+          <acceleration>0.01676 0.035013 -0.116164 0.012738 0.044127 0.036202</acceleration>
+          <wrench>0.00838 0.017506 -0.058082 0 -0 0</wrench>
+        </link>
+        <link name='wamv/base_link'>
+          <pose>-524.133 201.207 -0.05872 0.002999 -0.001082 1.00036</pose>
+          <velocity>0.002027 0.003541 0.030124 0.011337 -0.025232 -0.000267</velocity>
+          <acceleration>-0.00171 -0.003075 -0.098646 -0.395312 -0.239366 -0.007123</acceleration>
+          <wrench>-0.312568 -0.562167 -18.0331 0 -0 0</wrench>
+        </link>
+        <link name='wamv/imu_wamv_link'>
+          <pose>-524.144 201.497 1.44204 0.002999 -0.001082 1.00036</pose>
+          <velocity>-0.035762 -0.01347 0.033145 0.011337 -0.025232 -0.000267</velocity>
+          <acceleration>0.018068 0.037593 -0.107248 -0.028244 0.013089 -2.8e-05</acceleration>
+          <wrench>0.001807 0.003759 -0.010725 0 -0 0</wrench>
+        </link>
+        <link name='wamv/ins_link'>
+          <pose>-524.144 201.497 1.44204 0.002999 -0.001082 1.00036</pose>
+          <velocity>-0.035762 -0.01347 0.033145 0.011337 -0.025232 -0.000267</velocity>
+          <acceleration>0.018068 0.037593 -0.107248 -0.027596 0.013439 -7.7e-05</acceleration>
+          <wrench>0.018068 0.037593 -0.107248 0 -0 0</wrench>
+        </link>
+      </model>
+      <light name='sun'>
+        <pose>0 0 10 0 -0 0</pose>
+      </light>
+    </state>
+  </world>
+</sdf>


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
In the navigator_gazebo/worlds directory I added the scan_code_tests directory containing world files for Task 5. The added worlds have the vehicle and the light display in various places relative to one another.


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->


https://github.com/user-attachments/assets/6a6768cb-27b3-4d56-b20d-16270608ff2b



## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closes #XXX" to link the issue to the PR and close it when the PR is merged. -->

\- Closes #1264 

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->

```
roslaunch navigator_launch simulation.launch world:=scan_code_tests/<name_of_world> use_mil_world:=True --screen
```
Where <name_of_world> can be replaced with the following:
- behind
- close
- left
- none
- multiple
- right

## About This PR
<!-- BELOW: Have you checked the following? --->

- [x ] I have updated documentation related to this change so that future members are aware of the changes I've made.
