### PR TITLE
python publisher for sdgps solution to hydrophone pings

### DIFF
--- a/mil_common/drivers/mil_passive_sonar/CMakeLists.txt
+++ b/mil_common/drivers/mil_passive_sonar/CMakeLists.txt
@@ -37,4 +37,4 @@ add_executable(sylphase_sonar_ros_bridge src/sylphase_ros_bridge.cpp)
 target_link_libraries(sylphase_sonar_ros_bridge ${catkin_LIBRARIES})
 add_dependencies(sylphase_sonar_ros_bridge ${catkin_EXPORTED_TARGETS})
 
-install(PROGRAMS scripts/ping_publisher.py scripts/ping_printer scripts/ping_logger scripts/ping_plotter scripts/hydrophones DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+install(PROGRAMS scripts/ping_publisher scripts/ping_printer scripts/ping_logger scripts/ping_plotter scripts/hydrophones DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/mil_common/drivers/mil_passive_sonar/CMakeLists.txt
+++ b/mil_common/drivers/mil_passive_sonar/CMakeLists.txt
@@ -37,4 +37,4 @@ add_executable(sylphase_sonar_ros_bridge src/sylphase_ros_bridge.cpp)
 target_link_libraries(sylphase_sonar_ros_bridge ${catkin_LIBRARIES})
 add_dependencies(sylphase_sonar_ros_bridge ${catkin_EXPORTED_TARGETS})
 
-install(PROGRAMS scripts/ping_printer scripts/ping_logger scripts/ping_plotter scripts/hydrophones DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+install(PROGRAMS scripts/ping_publisher.py scripts/ping_printer scripts/ping_logger scripts/ping_plotter scripts/hydrophones DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/mil_common/drivers/mil_passive_sonar/scripts/ping_publisher.py
+++ b/mil_common/drivers/mil_passive_sonar/scripts/ping_publisher.py
@@ -13,32 +13,35 @@ from std_msgs.msg import Header
 def main():
     # Define the server address and port
     HOST = "127.0.0.1"
-    PORT = 2007  # The port used by the server
+    PORT = 2007
 
     # Create a socket
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        pub = rospy.Publisher("hydrophones/solved", ProcessedPing, queue_size=10)
         s.connect((HOST, PORT))
-        print(f"Connected to {HOST}:{PORT}")
-        pub = rospy.Publisher("ping", ProcessedPing, queue_size=10)
-        rospy.init_node("pingpublisher", anonymous=True)
+        rospy.loginfo(
+            f"\nConnected to {HOST}:{PORT}\nPublishing to /hydrophones/solved",
+        )
+
+        # Need to ignore the first 2 JSON Parse Errors (nothing wrong)
+        parse_error_count = 0
 
         while not rospy.is_shutdown():
             # Receive data
-            data = s.recv(1024)  # Buffer size is 1024 bytes
+            data = s.recv(1024)
             if not data:
                 break
 
             # Parse the JSON data
             try:
                 json_data = json.loads(data.decode("utf-8"))
-                # Create a ProcessedPing message
                 ping_msg = ProcessedPing()
 
                 # Populate the header
                 ping_msg.header = Header()
-                ping_msg.header.seq += 1  # Increment sequence number
+                ping_msg.header.seq += 1
                 ping_msg.header.stamp = rospy.Time.now()
-                ping_msg.header.frame_id = "ping_frame"  # Set your frame_id
+                ping_msg.header.frame_id = "hydrophones"
 
                 # Populate the position
                 ping_msg.position = Point()
@@ -48,21 +51,21 @@ def main():
 
                 # Populate the frequency and amplitude
                 ping_msg.freq = json_data["frequency_Hz"]
-                ping_msg.amplitude = json_data[
-                    "origin_distance_m"
-                ]  # You can modify this as needed
-                ping_msg.valid = True  # Or set to False based on your logic
+                ping_msg.amplitude = json_data["origin_distance_m"]
+                ping_msg.valid = True
 
                 # Publish the message
                 pub.publish(ping_msg)
-                rospy.loginfo(f"Published: {ping_msg}")
-
             except json.JSONDecodeError as e:
-                rospy.loginfo(f"JSON Decode Error: {e}")
+                parse_error_count += 1
+                # ignore first two (normal behavior)
+                if parse_error_count > 2:
+                    rospy.logerr(f"JSONDecodeError: {e}")
             except KeyError as e:
-                rospy.loginfo(f"Key Error: {e}")
+                rospy.logerr(f"Key Error: {e}")
 
 
 if __name__ == "__main__":
     with contextlib.suppress(rospy.ROSInterruptException):
+        rospy.init_node("pingpublisher", anonymous=True)
         main()

--- a/mil_common/drivers/mil_passive_sonar/scripts/ping_publisher.py
+++ b/mil_common/drivers/mil_passive_sonar/scripts/ping_publisher.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import contextlib
+import json
+import socket
+
+import rospy
+from geometry_msgs.msg import Point
+from mil_passive_sonar.msg import ProcessedPing
+from std_msgs.msg import Header
+
+
+def main():
+    # Define the server address and port
+    HOST = "127.0.0.1"
+    PORT = 2007  # The port used by the server
+
+    # Create a socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.connect((HOST, PORT))
+        print(f"Connected to {HOST}:{PORT}")
+        pub = rospy.Publisher("ping", ProcessedPing, queue_size=10)
+        rospy.init_node("pingpublisher", anonymous=True)
+
+        while not rospy.is_shutdown():
+            # Receive data
+            data = s.recv(1024)  # Buffer size is 1024 bytes
+            if not data:
+                break
+
+            # Parse the JSON data
+            try:
+                json_data = json.loads(data.decode("utf-8"))
+                # Create a ProcessedPing message
+                ping_msg = ProcessedPing()
+
+                # Populate the header
+                ping_msg.header = Header()
+                ping_msg.header.seq += 1  # Increment sequence number
+                ping_msg.header.stamp = rospy.Time.now()
+                ping_msg.header.frame_id = "ping_frame"  # Set your frame_id
+
+                # Populate the position
+                ping_msg.position = Point()
+                ping_msg.position.x = json_data["origin_direction_body"][0]
+                ping_msg.position.y = json_data["origin_direction_body"][1]
+                ping_msg.position.z = json_data["origin_direction_body"][2]
+
+                # Populate the frequency and amplitude
+                ping_msg.freq = json_data["frequency_Hz"]
+                ping_msg.amplitude = json_data[
+                    "origin_distance_m"
+                ]  # You can modify this as needed
+                ping_msg.valid = True  # Or set to False based on your logic
+
+                # Publish the message
+                pub.publish(ping_msg)
+                rospy.loginfo(f"Published: {ping_msg}")
+
+            except json.JSONDecodeError as e:
+                rospy.loginfo(f"JSON Decode Error: {e}")
+            except KeyError as e:
+                rospy.loginfo(f"Key Error: {e}")
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(rospy.ROSInterruptException):
+        main()

--- a/mil_common/drivers/mil_passive_sonar/scripts/ping_publisher.py
+++ b/mil_common/drivers/mil_passive_sonar/scripts/ping_publisher.py
@@ -20,7 +20,7 @@ def main():
         pub = rospy.Publisher("hydrophones/solved", ProcessedPing, queue_size=10)
         s.connect((HOST, PORT))
         rospy.loginfo(
-            f"\nConnected to {HOST}:{PORT}\nPublishing to /hydrophones/solved",
+            f"\nping_publisher connected to {HOST}:{PORT}, forwarding TCP messages to {pub.resolved_name}...",
         )
 
         # Need to ignore the first 2 JSON Parse Errors (nothing wrong)

--- a/mil_common/drivers/mil_passive_sonar/src/fakeping_pipeline.sh
+++ b/mil_common/drivers/mil_passive_sonar/src/fakeping_pipeline.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sdgps generate-fake-sonar-solution --rate 1 --position '[-30, 10, -2]' --circle '{"radius":3,"axis":[0,0,1],"period":30}' ! sonar-simulate --role rover --transmit-pattern robosub-2019 --base-hydrophone-arrangement robosub-2019 --rover-hydrophone-arrangement uf-mil-sub7 --cn0 80 --multipath extreme ! filter-sonar-raw-samples --highpass 15e3 --lowpass 45e3 --notch 40e3 ! extract-robosub-pings ! robosub-ping-solver ! listen-robosub-ping-solution-tcp 2007

--- a/mil_common/drivers/mil_passive_sonar/src/pipeline.sh
+++ b/mil_common/drivers/mil_passive_sonar/src/pipeline.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sdgps connect-sonar-raw-tcp --host 192.168.37.51 --port 2006 ! filter-sonar-raw-samples --highpass 15e3 --lowpass 45e3 --notch 40e3 ! extract-robosub-pings ! robosub-ping-solver ! listen-robosub-ping-solution-tcp 2007
+sdgps connect-sonar-raw-tcp --host 192.168.37.61 --port 2006 ! filter-sonar-raw-samples --highpass 15e3 --lowpass 45e3 --notch 40e3 ! extract-robosub-pings ! robosub-ping-solver ! listen-robosub-ping-solution-tcp 2007

--- a/mil_common/drivers/mil_passive_sonar/src/pipeline.sh
+++ b/mil_common/drivers/mil_passive_sonar/src/pipeline.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sdgps connect-sonar-raw-tcp --host 192.168.37.51 --port 2006 ! filter-sonar-raw-samples --highpass 15e3 --lowpass 45e3 --notch 40e3 ! extract-robosub-pings ! robosub-ping-solver ! listen-robosub-ping-solution-tcp 2007


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
This PR creates a bash script pipeline for posting the sdgps ping solution message over TCP (fakeping_pipeline.sh creates a fake ping for testing, and pipeline.sh receives real hydrophone pings).  Then, when running the python node ping_publisher.py, it will accept those TCP messages and publish them to the ROS node /ping for future use. These changes are part of the ROS package mil_passive_sonar.

## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->
<img width="1440" alt="Screenshot 2024-10-19 at 8 11 05 PM" src="https://github.com/user-attachments/assets/3b39584f-1a3f-41d0-a5e2-d2cf0c925128">
Each panel started in order: 
Bottom: Debug messages after running "rosrun mil_passive_sonar fakeping_pipeline.sh"
Upper left: Debug messages after running "rosrun mil_passive_sonar ping_publisher.py"
Upper right: Desired result of running "rostopic echo /ping"

## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closes #XXX" to link the issue to the PR and close it when the PR is merged. -->

\- Closes #1288

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
As shown in the image above, open three terminal windows (in tmux for ease of access). In one, run "rosrun mil_passive_sonar fakeping_pipeline.sh". In the next, run "rosrun mil_passive_sonar ping_publisher.py". In the final, use "rostopic echo /ping" to see the published ROS messages in the topic /ping.

I expect pipeline.sh to behave the same in place of fakeping_pipeline.sh, and intend to test with the boat at tomorrow's session.

## About This PR
<!-- BELOW: Have you checked the following? --->

- [ ] I have updated documentation related to this change so that future members are aware of the changes I've made.
