### PR TITLE
1281 migrate simulated and world camera topic names to consistent format

### DIFF
--- a/NaviGator/mission_control/navigator_launch/launch/simulation.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/simulation.launch
@@ -33,6 +33,7 @@
         <arg name="use_yolo_model2" value="False"/>
         <arg name="weights_model1" value="$(find yolov7_ros)/src/mil_weights/best.pt" />
 
+        <!-- Remaps old simulation-specific camera topic name to real-life camera topic name -->
         <remap from="/wamv/sensors/camera/front_left_cam/image_raw" to="/camera/front/left/image_raw"/>
     </include>
     <include file="$(find navigator_launch)/launch/vrx/vrx_tf.launch" />

--- a/NaviGator/mission_control/navigator_launch/launch/simulation.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/simulation.launch
@@ -28,10 +28,12 @@
 
     <!-- Simulation Relevant Code -->
     <include file="$(find navigator_launch)/launch/perception/classifier.launch" >
-        <arg name="main_image_topic" value="/camera/front/left/image_raw"/>
+        <arg name="main_image_topic" value="/wamv/sensors/camera/front_left_cam/image_raw"/>
         <arg name="use_yolo_model1" value="True"/>
         <arg name="use_yolo_model2" value="False"/>
         <arg name="weights_model1" value="$(find yolov7_ros)/src/mil_weights/best.pt" />
+
+        <remap from="/wamv/sensors/camera/front_left_cam/image_raw" to="camera/front/left/image_raw"/>
     </include>
     <include file="$(find navigator_launch)/launch/vrx/vrx_tf.launch" />
     <include file="$(find navigator_launch)/launch/vrx/vrx_localization.launch" />

--- a/NaviGator/mission_control/navigator_launch/launch/simulation.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/simulation.launch
@@ -33,7 +33,7 @@
         <arg name="use_yolo_model2" value="False"/>
         <arg name="weights_model1" value="$(find yolov7_ros)/src/mil_weights/best.pt" />
 
-        <remap from="/wamv/sensors/camera/front_left_cam/image_raw" to="camera/front/left/image_raw"/>
+        <remap from="/wamv/sensors/camera/front_left_cam/image_raw" to="/camera/front/left/image_raw"/>
     </include>
     <include file="$(find navigator_launch)/launch/vrx/vrx_tf.launch" />
     <include file="$(find navigator_launch)/launch/vrx/vrx_localization.launch" />

--- a/NaviGator/mission_control/navigator_launch/launch/simulation.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/simulation.launch
@@ -28,7 +28,7 @@
 
     <!-- Simulation Relevant Code -->
     <include file="$(find navigator_launch)/launch/perception/classifier.launch" >
-        <arg name="main_image_topic" value="/wamv/sensors/camera/front_left_cam/image_raw"/>
+        <arg name="main_image_topic" value="camera/front_left_cam/image_raw"/>
         <arg name="use_yolo_model1" value="True"/>
         <arg name="use_yolo_model2" value="False"/>
         <arg name="weights_model1" value="$(find yolov7_ros)/src/mil_weights/best.pt" />

--- a/NaviGator/mission_control/navigator_launch/launch/simulation.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/simulation.launch
@@ -28,7 +28,7 @@
 
     <!-- Simulation Relevant Code -->
     <include file="$(find navigator_launch)/launch/perception/classifier.launch" >
-        <arg name="main_image_topic" value="camera/front_left_cam/image_raw"/>
+        <arg name="main_image_topic" value="/camera/front_left_cam/image_raw"/>
         <arg name="use_yolo_model1" value="True"/>
         <arg name="use_yolo_model2" value="False"/>
         <arg name="weights_model1" value="$(find yolov7_ros)/src/mil_weights/best.pt" />

--- a/NaviGator/mission_control/navigator_launch/launch/simulation.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/simulation.launch
@@ -28,7 +28,7 @@
 
     <!-- Simulation Relevant Code -->
     <include file="$(find navigator_launch)/launch/perception/classifier.launch" >
-        <arg name="main_image_topic" value="/camera/front_left_cam/image_raw"/>
+        <arg name="main_image_topic" value="/camera/front/left/image_raw"/>
         <arg name="use_yolo_model1" value="True"/>
         <arg name="use_yolo_model2" value="False"/>
         <arg name="weights_model1" value="$(find yolov7_ros)/src/mil_weights/best.pt" />

--- a/NaviGator/mission_control/navigator_launch/launch/vrx/vrx_classifier.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/vrx/vrx_classifier.launch
@@ -9,7 +9,7 @@
     <arg name="device" default="cpu" />
     <arg name="use_yolo" default="False"/>
 
-    <remap from="/wamv/sensors/cameras/front_left_camera/image_raw" to="camera/front/left/image_raw"/>
+    <remap from="/wamv/sensors/cameras/front_left_camera/image_raw" to="/camera/front/left/image_raw"/>
 
     <!-- Use YOLOv7 -->
     <include if="$(arg use_yolo)" file="$(find yolov7_ros)/launch/yolov7.launch">

--- a/NaviGator/mission_control/navigator_launch/launch/vrx/vrx_classifier.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/vrx/vrx_classifier.launch
@@ -9,6 +9,7 @@
     <arg name="device" default="cpu" />
     <arg name="use_yolo" default="False"/>
 
+    <!-- Remaps old simulation-specific camera topic name to real-life camera topic name -->
     <remap from="/wamv/sensors/cameras/front_left_camera/image_raw" to="/camera/front/left/image_raw"/>
 
     <!-- Use YOLOv7 -->

--- a/NaviGator/mission_control/navigator_launch/launch/vrx/vrx_classifier.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/vrx/vrx_classifier.launch
@@ -2,12 +2,14 @@
 <launch>
 
     <arg name="weights" default="$(find yolov7_ros)/src/mil_weights/best.pt" />
-    <arg name="image_topic" default="/cameras/front/left/image_raw" />
+    <arg name="image_topic" default="/wamv/sensors/cameras/front_left_camera/image_raw" />
     <arg name="out_topic" default="detections" />
     <arg name="conf_thresh" default="0.75" />
     <arg name="image_size" default="640" />
     <arg name="device" default="cpu" />
     <arg name="use_yolo" default="False"/>
+
+    <remap from="/wamv/sensors/cameras/front_left_camera/image_raw" to="camera/front/left/image_raw"/>
 
     <!-- Use YOLOv7 -->
     <include if="$(arg use_yolo)" file="$(find yolov7_ros)/launch/yolov7.launch">

--- a/NaviGator/mission_control/navigator_launch/launch/vrx/vrx_classifier.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/vrx/vrx_classifier.launch
@@ -2,7 +2,7 @@
 <launch>
 
     <arg name="weights" default="$(find yolov7_ros)/src/mil_weights/best.pt" />
-    <arg name="image_topic" default="/camera/front/left/image_raw" />
+    <arg name="image_topic" default="/cameras/front/left/image_raw" />
     <arg name="out_topic" default="detections" />
     <arg name="conf_thresh" default="0.75" />
     <arg name="image_size" default="640" />

--- a/NaviGator/mission_control/navigator_launch/launch/vrx/vrx_classifier.launch
+++ b/NaviGator/mission_control/navigator_launch/launch/vrx/vrx_classifier.launch
@@ -2,7 +2,7 @@
 <launch>
 
     <arg name="weights" default="$(find yolov7_ros)/src/mil_weights/best.pt" />
-    <arg name="image_topic" default="/wamv/sensors/cameras/front_left_camera/image_raw" />
+    <arg name="image_topic" default="/camera/front/left/image_raw" />
     <arg name="out_topic" default="detections" />
     <arg name="conf_thresh" default="0.75" />
     <arg name="image_size" default="640" />

--- a/NaviGator/mission_control/navigator_missions/navigator_missions/navigator.py
+++ b/NaviGator/mission_control/navigator_missions/navigator_missions/navigator.py
@@ -317,13 +317,13 @@ class NaviGatorMission(BaseMission):
     async def init_front_left_camera(cls):
         if cls.front_left_camera_sub is None:
             cls.front_left_camera_sub = cls.nh.subscribe(
-                "/wamv/sensors/camera/front_left_cam/image_raw",
+                "/camera/front_left_cam/image_raw",
                 Image,
             )
 
         if cls.front_left_camera_info_sub is None:
             cls.front_left_camera_info_sub = cls.nh.subscribe(
-                "/wamv/sensors/camera/front_left_cam/camera_info",
+                "/camera/front_left_cam/camera_info",
                 CameraInfo,
             )
 
@@ -336,13 +336,13 @@ class NaviGatorMission(BaseMission):
     async def init_front_right_camera(cls):
         if cls.front_right_camera_sub is None:
             cls.front_right_camera_sub = cls.nh.subscribe(
-                "/wamv/sensors/camera/front_right_cam/image_raw",
+                "/camera/front_right_cam/image_raw",
                 Image,
             )
 
         if cls.front_right_camera_info_sub is None:
             cls.front_right_camera_info_sub = cls.nh.subscribe(
-                "/wamv/sensors/camera/front_right_cam/camera_info",
+                "/camera/front_right_cam/camera_info",
                 CameraInfo,
             )
 

--- a/NaviGator/mission_control/navigator_missions/navigator_missions/navigator.py
+++ b/NaviGator/mission_control/navigator_missions/navigator_missions/navigator.py
@@ -317,13 +317,13 @@ class NaviGatorMission(BaseMission):
     async def init_front_left_camera(cls):
         if cls.front_left_camera_sub is None:
             cls.front_left_camera_sub = cls.nh.subscribe(
-                "/camera/front_left_cam/image_raw",
+                "/camera/front/left/image_raw",
                 Image,
             )
 
         if cls.front_left_camera_info_sub is None:
             cls.front_left_camera_info_sub = cls.nh.subscribe(
-                "/camera/front_left_cam/camera_info",
+                "/camera/front/left/camera_info",
                 CameraInfo,
             )
 
@@ -336,13 +336,13 @@ class NaviGatorMission(BaseMission):
     async def init_front_right_camera(cls):
         if cls.front_right_camera_sub is None:
             cls.front_right_camera_sub = cls.nh.subscribe(
-                "/camera/front_right_cam/image_raw",
+                "/camera/front/right/image_raw",
                 Image,
             )
 
         if cls.front_right_camera_info_sub is None:
             cls.front_right_camera_info_sub = cls.nh.subscribe(
-                "/camera/front_right_cam/camera_info",
+                "/camera/front/right/camera_info",
                 CameraInfo,
             )
 

--- a/NaviGator/mission_control/navigator_missions/vrx_missions/vrx.py
+++ b/NaviGator/mission_control/navigator_missions/vrx_missions/vrx.py
@@ -134,13 +134,13 @@ class Vrx(NaviGatorMission):
     async def init_front_left_camera(cls):
         if cls.front_left_camera_sub is None:
             cls.front_left_camera_sub = cls.nh.subscribe(
-                "/camera/front/left/image_raw",
+                "/cameras/front/left/image_raw",
                 Image,
             )
 
         if cls.front_left_camera_info_sub is None:
             cls.front_left_camera_info_sub = cls.nh.subscribe(
-                "/camera/front/left/camera_info",
+                "/cameras/front/left/camera_info",
                 CameraInfo,
             )
 
@@ -153,13 +153,13 @@ class Vrx(NaviGatorMission):
     async def init_front_right_camera(cls):
         if cls.front_right_camera_sub is None:
             cls.front_right_camera_sub = cls.nh.subscribe(
-                "/camera/front/right/image_raw",
+                "/cameras/front/right/image_raw",
                 Image,
             )
 
         if cls.front_right_camera_info_sub is None:
             cls.front_right_camera_info_sub = cls.nh.subscribe(
-                "/camera/front/right/camera_info",
+                "/cameras/front/right/camera_info",
                 CameraInfo,
             )
 

--- a/NaviGator/mission_control/navigator_missions/vrx_missions/vrx.py
+++ b/NaviGator/mission_control/navigator_missions/vrx_missions/vrx.py
@@ -134,13 +134,13 @@ class Vrx(NaviGatorMission):
     async def init_front_left_camera(cls):
         if cls.front_left_camera_sub is None:
             cls.front_left_camera_sub = cls.nh.subscribe(
-                "/wamv/sensors/cameras/front_left_camera/image_raw",
+                "/camera/front/left/image_raw",
                 Image,
             )
 
         if cls.front_left_camera_info_sub is None:
             cls.front_left_camera_info_sub = cls.nh.subscribe(
-                "/wamv/sensors/cameras/front_left_camera/camera_info",
+                "/camera/front/left/camera_info",
                 CameraInfo,
             )
 
@@ -153,13 +153,13 @@ class Vrx(NaviGatorMission):
     async def init_front_right_camera(cls):
         if cls.front_right_camera_sub is None:
             cls.front_right_camera_sub = cls.nh.subscribe(
-                "/wamv/sensors/cameras/front_right_camera/image_raw",
+                "/camera/front/right/image_raw",
                 Image,
             )
 
         if cls.front_right_camera_info_sub is None:
             cls.front_right_camera_info_sub = cls.nh.subscribe(
-                "/wamv/sensors/cameras/front_right_camera/camera_info",
+                "/camera/front/right/camera_info",
                 CameraInfo,
             )
 

--- a/NaviGator/mission_control/navigator_missions/vrx_missions/vrx.py
+++ b/NaviGator/mission_control/navigator_missions/vrx_missions/vrx.py
@@ -134,13 +134,13 @@ class Vrx(NaviGatorMission):
     async def init_front_left_camera(cls):
         if cls.front_left_camera_sub is None:
             cls.front_left_camera_sub = cls.nh.subscribe(
-                "/cameras/front/left/image_raw",
+                "/camera/front/left/image_raw",
                 Image,
             )
 
         if cls.front_left_camera_info_sub is None:
             cls.front_left_camera_info_sub = cls.nh.subscribe(
-                "/cameras/front/left/camera_info",
+                "/camera/front/left/camera_info",
                 CameraInfo,
             )
 
@@ -153,13 +153,13 @@ class Vrx(NaviGatorMission):
     async def init_front_right_camera(cls):
         if cls.front_right_camera_sub is None:
             cls.front_right_camera_sub = cls.nh.subscribe(
-                "/cameras/front/right/image_raw",
+                "/camera/front/right/image_raw",
                 Image,
             )
 
         if cls.front_right_camera_info_sub is None:
             cls.front_right_camera_info_sub = cls.nh.subscribe(
-                "/cameras/front/right/camera_info",
+                "/camera/front/right/camera_info",
                 CameraInfo,
             )
 

--- a/NaviGator/navigator.rviz
+++ b/NaviGator/navigator.rviz
@@ -344,7 +344,7 @@ Visualization Manager:
       Value: true
     - Class: rviz/Image
       Enabled: true
-      Image Topic: /wamv/sensors/camera/front_left_cam/image_raw
+      Image Topic: /camera/front/left/image_raw
       Max Value: 1
       Median window: 5
       Min Value: 0

--- a/NaviGator/vrx.rviz
+++ b/NaviGator/vrx.rviz
@@ -420,7 +420,7 @@ Visualization Manager:
       Value: true
     - Class: rviz/Image
       Enabled: true
-      Image Topic: /wamv/sensors/cameras/front_left_camera/image_raw
+      Image Topic: camera/front/left/image_raw
       Max Value: 1
       Median window: 5
       Min Value: 0

--- a/NaviGator/vrx.rviz
+++ b/NaviGator/vrx.rviz
@@ -420,7 +420,7 @@ Visualization Manager:
       Value: true
     - Class: rviz/Image
       Enabled: true
-      Image Topic: camera/front/left/image_raw
+      Image Topic: /camera/front/left/image_raw
       Max Value: 1
       Median window: 5
       Min Value: 0

--- a/NaviGator/vrx.rviz
+++ b/NaviGator/vrx.rviz
@@ -420,7 +420,7 @@ Visualization Manager:
       Value: true
     - Class: rviz/Image
       Enabled: true
-      Image Topic: cameras/front/left/image_raw
+      Image Topic: camera/front/left/image_raw
       Max Value: 1
       Median window: 5
       Min Value: 0

--- a/NaviGator/vrx.rviz
+++ b/NaviGator/vrx.rviz
@@ -420,7 +420,7 @@ Visualization Manager:
       Value: true
     - Class: rviz/Image
       Enabled: true
-      Image Topic: camera/front/left/image_raw
+      Image Topic: cameras/front/left/image_raw
       Max Value: 1
       Median window: 5
       Min Value: 0


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
I was able to migrate the simulated camera topics to the real-world camera topics by remapping the old simulation-specific topic names onto the new real-life topic names inside NaviGator/mission_control/navigator_launch/launch/simulation.launch and NaviGator/mission_control/navigator_launch/launch/vrx/vrx_classifier.launch.

 I also changed the simulation topic names to their real-life versions inside of all of the files they appeared in.


## Screenshot or Video
<!-- BELOW: Add a screenshot/video showing your change working. This helps reviewers understand what the expected behavior of this PR is without needing to write a long description. -->
![Migrate Camera Topic Names Screenshot](https://github.com/user-attachments/assets/862c3dd1-d898-40f1-ba57-f6b171365f55)



## Related Issues
<!-- BELOW: What issues are closed by this PR? Write "Closes #1281" to link the issue to the PR and close it when the PR is merged. -->

\- Closes #1281

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->

Just launch Navigator using this template command for worlds inside NaviGator/simulation/navigator_gazebo/worlds. 

roslaunch navigator_launch simulation.launch use_mil_world:=True world:=<world> --screen

## About This PR
<!-- BELOW: Have you checked the following? --->

- [x] I have updated documentation related to this change so that future members are aware of the changes I've made.
