### PR TITLE
bash alias 'ntmux'

### DIFF
--- a/NaviGator/scripts/tmux_start.sh
+++ b/NaviGator/scripts/tmux_start.sh
@@ -2,18 +2,24 @@
 if tmux has-session -t auto; then
 	tmux a -t auto
 else
+	# First window (panes)
 	tmux new-session -d -s auto
 	tmux send-keys -t auto:0.0 'roslaunch navigator_launch master.launch --screen' Enter
 	tmux split-window -h -t auto
 	tmux split-window -v -t auto
+
+	# Second window (alarms, other panes)
+	sleep 1.5
 	tmux new-window -t auto
 	tmux split-window -h -t auto:1
 	tmux split-window -v -t auto:1
 	tmux split-window -v -t auto:1.0
-	sleep 1.5
 	tmux send-keys 'amonitor kill' Enter
 	tmux split-window -h
 	tmux send-keys 'amonitor hw-kill' Enter
 	tmux select-pane -t auto:1.0
+
+	# Return to the first window
+	tmux select-window -t auto:0
 	tmux a -t auto
 fi

--- a/NaviGator/scripts/tmux_start.sh
+++ b/NaviGator/scripts/tmux_start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+if tmux has-session -t auto; then
+	tmux a -t auto
+else
+	tmux new-session -d -s auto
+	tmux send-keys -t auto:0.0 'roslaunch navigator_launch master.launch --screen' Enter
+	tmux split-window -h -t auto
+	tmux split-window -v -t auto
+	tmux new-window -t auto
+	tmux split-window -h -t auto:1
+	tmux split-window -v -t auto:1
+	tmux split-window -v -t auto:1.0
+	sleep 1.5
+	tmux send-keys 'amonitor kill' Enter
+	tmux split-window -h
+	tmux send-keys 'amonitor hw-kill' Enter
+	tmux select-pane -t auto:1.0
+	tmux a -t auto
+fi

--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -91,6 +91,7 @@ alias gazebogui="rosrun gazebo_ros gzclient __name:=gzclient"
 
 # Preflight aliases
 alias preflight='python3 $MIL_REPO/mil_common/utils/mil_tools/scripts/mil-preflight/main.py'
+alias ntmux='$MIL_REPO/NaviGator/scripts/tmux_start.sh'
 
 # Process killing aliases
 alias killgazebo="killall -9 gzserver && killall -9 gzclient"


### PR DESCRIPTION
## Description
<!-- BELOW: What did you change in this PR? -->
Sets up a bash alias called 'ntmux' short for Navigator tmux, that opens tmux session called 'auto' with two windows. It launches navigator and sets up kill monitors, as well as blank panes for additional commands.

## Testing
<!-- BELOW: Briefly explain how someone can go about testing your PR. -->
Run 'ntmux' and check the appropriate session is started or is opened.